### PR TITLE
Write Arrow buffer into host shared memory in CPU mode

### DIFF
--- a/QueryEngine/ResultSet.h
+++ b/QueryEngine/ResultSet.h
@@ -285,6 +285,10 @@ class ResultSet {
   static std::unique_ptr<ResultSet> unserialize(const std::string&, const Executor*);
 
 #ifdef ENABLE_ARROW_CONVERTER
+  std::tuple<std::shared_ptr<arrow::Buffer>, std::vector<char>, int64_t> getArrowCopy(
+      Data_Namespace::DataMgr* data_mgr,
+      const std::vector<std::string>& col_names) const;
+
   std::tuple<std::shared_ptr<arrow::Buffer>, std::vector<char>, int64_t> getArrowDeviceCopy(
       Data_Namespace::DataMgr* data_mgr,
       const size_t device_id,

--- a/ThriftHandler/MapDHandler.h
+++ b/ThriftHandler/MapDHandler.h
@@ -143,6 +143,10 @@ class MapDHandler : public MapDIf {
                    const bool column_format,
                    const std::string& nonce,
                    const int32_t first_n);
+  void sql_execute_df(TGpuDataFrame& _return,
+                      const TSessionId& session,
+                      const std::string& query,
+                      const int32_t first_n);
   void sql_execute_gpudf(TGpuDataFrame& _return,
                          const TSessionId& session,
                          const std::string& query,
@@ -308,6 +312,10 @@ class MapDHandler : public MapDIf {
                        const bool just_explain,
                        const bool just_validate) const;
 #ifdef ENABLE_ARROW_CONVERTER
+  void execute_rel_alg_df(TGpuDataFrame& _return,
+                          const std::string& query_ra,
+                          const Catalog_Namespace::SessionInfo& session_info,
+                          const int32_t first_n) const;
   void execute_rel_alg_gpudf(TGpuDataFrame& _return,
                              const std::string& query_ra,
                              const Catalog_Namespace::SessionInfo& session_info,
@@ -359,6 +367,10 @@ class MapDHandler : public MapDIf {
       const std::vector<std::shared_ptr<Analyzer::TargetEntry>>& targets) const;
 
 #ifdef ENABLE_ARROW_CONVERTER
+  void execute_root_plan_df(TGpuDataFrame& _return,
+                            const Planner::RootPlan* root_plan,
+                            const Catalog_Namespace::SessionInfo& session_info,
+                            const int32_t first_n) const;
   void execute_root_plan_gpudf(TGpuDataFrame& _return,
                                const Planner::RootPlan* root_plan,
                                const Catalog_Namespace::SessionInfo& session_info,

--- a/mapd.thrift
+++ b/mapd.thrift
@@ -342,6 +342,7 @@ service MapD {
   void clear_gpu_memory(1: TSessionId session) throws (1: TMapDException e)
   # query, render
   TQueryResult sql_execute(1: TSessionId session, 2: string query 3: bool column_format, 4: string nonce, 5: i32 first_n = -1) throws (1: TMapDException e)
+  TGpuDataFrame sql_execute_df(1: TSessionId session, 2: string query 3: i32 first_n = -1) throws (1: TMapDException e)
   TGpuDataFrame sql_execute_gpudf(1: TSessionId session, 2: string query 3: i32 device_id = 0, 4: i32 first_n = -1) throws (1: TMapDException e)
   void interrupt(1: TSessionId session) throws (1: TMapDException e)
   TTableDescriptor sql_validate(1: TSessionId session, 2: string query) throws (1: TMapDException e)


### PR DESCRIPTION
cc: @andrewseidl 

This PR is a starting point for writing the serialized Arrow buffer to host shared memory in CPU mode via [`shmget`](http://man7.org/linux/man-pages/man2/shmget.2.html). I've tested it works locally on macOS Sierra 10.12.5, though it should work on any System V platform.

My C++ fu is not strong, so I cargo-culted the ThriftHandler. I implemented new code paths to reduce the risk of introducing new bugs. I expect someone from the team will want to delete or rewrite this code to conform to the coding guidelines.

The core logic is in [`ResultSet::getArrowCopy`](https://github.com/mapd/mapd-core/compare/master...graphistry:shm-ipc#diff-3055c0b6e6034b731c9cdad3b3cd3121R529). I've added comments inline with the following questions/todos:
- I've used stdlib rand() to [generate unique shmid keys](https://github.com/mapd/mapd-core/compare/master...graphistry:shm-ipc#diff-3055c0b6e6034b731c9cdad3b3cd3121R541). Are there any flaws in this approach?
- if [`shmget` or `shmat` fail](https://github.com/mapd/mapd-core/compare/master...graphistry:shm-ipc#diff-3055c0b6e6034b731c9cdad3b3cd3121R560), the error should be surfaced to the caller (needs rewrite following mapd-core guidelines)
- it should be possible to serialize the arrow buffer directly to shared memory, but I'm not familiar with the C++ Streams API. I've [hacked it with a memcpy](https://github.com/mapd/mapd-core/compare/master...graphistry:shm-ipc#diff-3055c0b6e6034b731c9cdad3b3cd3121R574) for now

Here's an example of calling the `sql_execute_df` method from node (see more in our [graphistry/rxjs-mapd](https://github.com/graphistry/rxjs-mapd) repo):

```javascript
// Assuming mapd-core is running with default settings and flights_2008_10k test database
import * as shm from 'shm-typed-array';
import { createClient, createConnection, TBinaryProtocol, TBufferedTransport } from 'thrift';
// These libs aren't in npm yet
// Arrow's JS impl has a bug that prevents it from reading data from
// columns that don't contain nulls. I patched it locally, and will PR them soon
import { getReader } from 'apache/arrow';
// run `thrift --gen js:node mapd.thrift` to get this code
import { Client as MapDClient } from 'mapd-thrift';

const client = createClient(MapDClient,  createConnection(`localhost`, 9091, {
  protocol: TBinaryProtocol, transport: TBufferedTransport
}));

client.connect(`mapd`, `HyperInteractive`, `mapd`)
  .then((session) => client.sql_execute_df(session, `SELECT origin_lat, origin_lon FROM flights_2008_10k WHERE dest_city ILIKE 'dallas'`, -1))
  .then(({ df_handle }) => getReader(shm.get(+df_handle, 'Buffer')))
  .then((arrow) => console.log(`col names: ${arrow
      .getSchema()
      .map(({ name }) => name)
      .join(', ')
    }`)
  );
```