### PR TITLE
cmake: Fixed arrow include directory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ option(ENABLE_ARROW_CONVERTER "Enable arrow converter" OFF)
 if(ENABLE_ARROW_CONVERTER)
   find_package(Arrow REQUIRED)
   add_definitions("-DENABLE_ARROW_CONVERTER")
-  include_directories(${Arrow_INCLUDE_DIR})
+  include_directories(${Arrow_INCLUDE_DIRS})
 endif()
 
 # RapidJSON


### PR DESCRIPTION
In https://github.com/mapd/mapd-core/blob/e745367c41c8dfa28487870816cf27a57a46204d/cmake/Modules/FindArrow.cmake#L62 we set `Arrow_INCLUDE_DIRS`, but the main `CMakeLists.txt` was using `Arrow_INCLUDE_DIR`, singular. Hopefully this is the right fix (I haven't used cmake before).

Before this, I could `cmake -DCMAKE_BUILD_TYPE=debug -DENABLE_CUDA=off -DENABLE_ARROW_CONVERTER=on -DArrow_LIBRARY=~/miniconda3/envs/mapd-dev/lib/libarrow.dylib ..` fine, but my `make` failed with

```
/Users/taugspurger/sandbox/mapd-core/QueryEngine/ResultSet.h:34:10: fatal error: 'arrow/table.h' file not found
#include "arrow/table.h"
 ```

I don't think this closes https://github.com/mapd/mapd-core/issues/25, as now my `make` fails with

```
[ 82%] Building CXX object QueryEngine/CMakeFiles/QueryEngine.dir/HashJoinRuntime.cpp.o
/Users/taugspurger/sandbox/mapd-core/QueryEngine/ResultSetConversion.cpp:359:22: error: no member named 'Open' in 'arrow::ipc::RecordBatchReader'
  ipc::StreamReader::Open(buf_reader, &reader);
  ~~~~~~~~~~~~~~~~~~~^
1 error generated.
make[2]: *** [QueryEngine/CMakeFiles/QueryEngine.dir/ResultSetConversion.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [QueryEngine/CMakeFiles/QueryEngine.dir/all] Error 2
make: *** [all] Error 2
```

I'm debugging that now.