### PR TITLE
Migrate Arrow-related code to incorporate IPC code improvements since 0.4.x, simplifications and perf improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,10 @@ list(APPEND MAPD_LIBRARIES Calcite)
 
 if(ENABLE_ARROW_CONVERTER)
   list(APPEND MAPD_LIBRARIES ${Arrow_LIBRARIES})
+
+  if(ENABLE_CUDA)
+    list(APPEND MAPD_LIBRARIES ${Arrow_GPU_LIBRARIES})
+  endif()
 endif()
 
 enable_testing()

--- a/QueryEngine/ArrowResultSet.cpp
+++ b/QueryEngine/ArrowResultSet.cpp
@@ -16,11 +16,12 @@
 
 #ifdef ENABLE_ARROW_CONVERTER
 #include "ArrowResultSet.h"
+#include "ArrowUtil.h"
 #include "RelAlgExecutionDescriptor.h"
 
-#include <arrow/array.h>
+#include <arrow/api.h>
 #include <arrow/io/memory.h>
-#include <arrow/ipc/reader.h>
+#include <arrow/ipc/api.h>
 
 namespace {
 
@@ -47,13 +48,14 @@ SQLTypeInfo type_from_arrow_field(const arrow::Field& field) {
 
 }  // namespace
 
-ArrowResultSet::ArrowResultSet(const std::shared_ptr<arrow::Schema>& schema,
-                               const std::shared_ptr<arrow::RecordBatch>& record_batch,
-                               const std::vector<std::shared_ptr<arrow::PoolBuffer>>& pool_buffers)
-    : record_batch_(record_batch), pool_buffers_(pool_buffers), crt_row_idx_(0) {
-  CHECK_EQ(schema->num_fields(), record_batch->num_columns());
+ArrowResultSet::ArrowResultSet(const std::shared_ptr<arrow::RecordBatch>& record_batch)
+    : record_batch_(record_batch), crt_row_idx_(0) {
+  auto schema = record_batch->schema();
   for (int i = 0; i < schema->num_fields(); ++i) {
-    column_metainfo_.emplace_back(schema->field(i)->name(), type_from_arrow_field(*schema->field(i)));
+    std::shared_ptr<arrow::Field> field = schema->field(i);
+    SQLTypeInfo type_info = type_from_arrow_field(*schema->field(i));
+    column_metainfo_.emplace_back(field->name(), type_info);
+    columns_.emplace_back(std::move(record_batch->column(i)));
   }
 }
 
@@ -64,52 +66,52 @@ std::vector<TargetValue> ArrowResultSet::getNextRow(const bool translate_strings
   CHECK_LT(crt_row_idx_, rowCount());
   std::vector<TargetValue> row;
   for (int i = 0; i < record_batch_->num_columns(); ++i) {
-    const auto& column = *record_batch_->column(i);
+    const auto& column = *columns_[i];
     const auto& column_typeinfo = getColType(i);
     switch (column_typeinfo.get_type()) {
       case kSMALLINT: {
-        CHECK(dynamic_cast<const arrow::NumericArray<arrow::Int16Type>*>(&column));
-        const auto& i16_column = static_cast<const arrow::NumericArray<arrow::Int16Type>&>(column);
+        CHECK_EQ(arrow::Type::INT16, column.type_id());
+        const auto& i16_column = static_cast<const arrow::Int16Array&>(column);
         row.emplace_back(i16_column.IsNull(crt_row_idx_) ? inline_int_null_val(column_typeinfo)
                                                          : static_cast<int64_t>(i16_column.Value(crt_row_idx_)));
         break;
       }
       case kINT: {
-        CHECK(dynamic_cast<const arrow::NumericArray<arrow::Int32Type>*>(&column));
-        const auto& i32_column = static_cast<const arrow::NumericArray<arrow::Int32Type>&>(column);
+        CHECK_EQ(arrow::Type::INT32, column.type_id());
+        const auto& i32_column = static_cast<const arrow::Int32Array&>(column);
         row.emplace_back(i32_column.IsNull(crt_row_idx_) ? inline_int_null_val(column_typeinfo)
                                                          : static_cast<int64_t>(i32_column.Value(crt_row_idx_)));
         break;
       }
       case kBIGINT: {
-        CHECK(dynamic_cast<const arrow::NumericArray<arrow::Int64Type>*>(&column));
-        const auto& i64_column = static_cast<const arrow::NumericArray<arrow::Int64Type>&>(column);
+        CHECK_EQ(arrow::Type::INT64, column.type_id());
+        const auto& i64_column = static_cast<const arrow::Int64Array&>(column);
         row.emplace_back(i64_column.IsNull(crt_row_idx_) ? inline_int_null_val(column_typeinfo)
                                                          : static_cast<int64_t>(i64_column.Value(crt_row_idx_)));
         break;
       }
       case kFLOAT: {
-        CHECK(dynamic_cast<const arrow::NumericArray<arrow::FloatType>*>(&column));
-        const auto& float_column = static_cast<const arrow::NumericArray<arrow::FloatType>&>(column);
+        CHECK_EQ(arrow::Type::FLOAT, column.type_id());
+        const auto& float_column = static_cast<const arrow::FloatArray&>(column);
         row.emplace_back(float_column.IsNull(crt_row_idx_) ? inline_fp_null_value<float>()
                                                            : float_column.Value(crt_row_idx_));
         break;
       }
       case kDOUBLE: {
-        CHECK(dynamic_cast<const arrow::NumericArray<arrow::DoubleType>*>(&column));
-        const auto& double_column = static_cast<const arrow::NumericArray<arrow::DoubleType>&>(column);
+        CHECK_EQ(arrow::Type::DOUBLE, column.type_id());
+        const auto& double_column = static_cast<const arrow::DoubleArray&>(column);
         row.emplace_back(double_column.IsNull(crt_row_idx_) ? inline_fp_null_value<double>()
                                                             : double_column.Value(crt_row_idx_));
         break;
       }
       case kTEXT: {
         CHECK_EQ(kENCODING_DICT, column_typeinfo.get_compression());
-        CHECK(dynamic_cast<const arrow::DictionaryArray*>(&column));
+        CHECK_EQ(arrow::Type::DICTIONARY, column.type_id());
         const auto& dict_column = static_cast<const arrow::DictionaryArray&>(column);
         if (dict_column.IsNull(crt_row_idx_)) {
           row.emplace_back(NullableString(nullptr));
         } else {
-          const auto& indices = static_cast<const arrow::NumericArray<arrow::Int32Type>&>(*dict_column.indices());
+          const auto& indices = static_cast<const arrow::Int32Array&>(*dict_column.indices());
           const auto& dictionary = static_cast<const arrow::StringArray&>(*dict_column.dictionary());
           row.emplace_back(dictionary.GetString(indices.Value(crt_row_idx_)));
         }
@@ -147,32 +149,27 @@ std::unique_ptr<ArrowResultSet> result_set_arrow_loopback(const ExecutionResult&
     col_names.push_back(target_meta.get_resname());
   }
   const auto serialized_arrow_output = results.getRows()->getSerializedArrowOutput(col_names);
-  const auto schema_payload =
-      std::make_shared<arrow::Buffer>(serialized_arrow_output.schema->data(), serialized_arrow_output.schema->size());
-  auto schema_buffer = std::make_shared<arrow::io::BufferReader>(schema_payload);
-  std::shared_ptr<arrow::ipc::RecordBatchStreamReader> schema_reader;
-  arrow::ipc::RecordBatchStreamReader::Open(schema_buffer, &schema_reader);
-  auto schema = schema_reader->schema();
-  const auto records_payload =
-      std::make_shared<arrow::Buffer>(serialized_arrow_output.records->data(), serialized_arrow_output.records->size());
-  auto records_buffer_reader = std::make_shared<arrow::io::BufferReader>(records_payload);
 
-  std::shared_ptr<arrow::ipc::Message> message;
-  arrow::ipc::ReadMessage(records_buffer_reader.get(), &message);
+  arrow::io::BufferReader schema_reader(serialized_arrow_output.schema);
 
-  // The buffer offsets start at 0, so we must construct a
-  // RandomAccessFile according to that frame of reference
-  std::shared_ptr<arrow::Buffer> body_payload;
-  records_buffer_reader->Read(message->body_length(), &body_payload);
-  arrow::io::BufferReader body_reader(body_payload);
+  std::shared_ptr<arrow::Schema> schema;
+  ARROW_THROW_NOT_OK(arrow::ipc::ReadSchema(&schema_reader, &schema));
 
   std::shared_ptr<arrow::RecordBatch> batch;
-  arrow::ipc::ReadRecordBatch(*message, schema, &body_reader, &batch);
+  arrow::io::BufferReader records_reader(serialized_arrow_output.records);
+  ARROW_THROW_NOT_OK(arrow::ipc::ReadRecordBatch(schema, &records_reader, &batch));
 
-  return boost::make_unique<ArrowResultSet>(
-      schema,
-      batch,
-      std::vector<std::shared_ptr<arrow::PoolBuffer>>{serialized_arrow_output.schema, serialized_arrow_output.records});
+  CHECK_EQ(schema->num_fields(), batch->num_columns());
+
+  // NOTE(wesm): About memory ownership
+
+  // After calling ReadRecordBatch, the buffers inside arrow::RecordBatch now
+  // share ownership of the memory in serialized_arrow_output.records (zero
+  // copy). Not necessary to retain these buffers. Same is true of any
+  // dictionaries contained in serialized_arrow_output.schema; the arrays
+  // reference that memory (zero copy).
+
+  return boost::make_unique<ArrowResultSet>(batch);
 }
 
 #endif  // ENABLE_ARROW_CONVERTER

--- a/QueryEngine/ArrowUtil.cpp
+++ b/QueryEngine/ArrowUtil.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ArrowUtil.h"
+#include "DataMgr/BufferMgr/BufferMgr.h"  // for OutOfMemory
+
+#include <string>
+
+#include "arrow/status.h"
+
+void arrow_status_throw(const ::arrow::Status& s) {
+  std::string message = s.ToString();
+  switch (s.code()) {
+    case ::arrow::StatusCode::OutOfMemory:
+      throw OutOfMemory(message);
+    default:
+      throw std::runtime_error(message);
+  }
+}

--- a/QueryEngine/ArrowUtil.h
+++ b/QueryEngine/ArrowUtil.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef QUERYENGINE_ARROW_UTIL_H
+#define QUERYENGINE_ARROW_UTIL_H
+
+#include "arrow/status.h"
+#include "arrow/util/macros.h"
+
+#include "Shared/likely.h"
+
+void arrow_status_throw(const ::arrow::Status& s);
+
+#define ARROW_THROW_NOT_OK(s) \
+  do {                        \
+    ::arrow::Status _s = (s); \
+    if (UNLIKELY(!_s.ok())) { \
+      arrow_status_throw(_s); \
+    }                         \
+  } while (0)
+
+#endif  // QUERYENGINE_ARROW_UTIL_H

--- a/QueryEngine/CMakeLists.txt
+++ b/QueryEngine/CMakeLists.txt
@@ -8,6 +8,7 @@ set(query_engine_source_files
     ArrayIR.cpp
     ArrayOps.cpp
     ArrowResultSet.cpp
+    ArrowUtil.cpp
     BaselineJoinHashTable.cpp
     CalciteAdapter.cpp
     CalciteDeserializerUtils.cpp

--- a/QueryEngine/ResultSet.h
+++ b/QueryEngine/ResultSet.h
@@ -31,9 +31,8 @@
 #include "../Chunk/Chunk.h"
 
 #ifdef ENABLE_ARROW_CONVERTER
-#include "arrow/ipc/metadata.h"
-#include "arrow/table.h"
-#include "arrow/buffer.h"
+#include "arrow/api.h"
+#include "arrow/ipc/api.h"
 // Arrow defines macro UNUSED conflict w/ that in jni_md.h
 #ifdef UNUSED
 #undef UNUSED
@@ -350,8 +349,8 @@ class ResultSet {
 
 #ifdef ENABLE_ARROW_CONVERTER
   struct SerializedArrowOutput {
-    std::shared_ptr<arrow::PoolBuffer> schema;
-    std::shared_ptr<arrow::PoolBuffer> records;
+    std::shared_ptr<arrow::Buffer> schema;
+    std::shared_ptr<arrow::Buffer> records;
   };
 
   SerializedArrowOutput getSerializedArrowOutput(const std::vector<std::string>& col_names) const;
@@ -470,10 +469,10 @@ class ResultSet {
   int getGpuCount() const;
 
 #ifdef ENABLE_ARROW_CONVERTER
-  arrow::RecordBatch convertToArrow(const std::vector<std::string>& col_names, arrow::ipc::DictionaryMemo& memo) const;
+  std::shared_ptr<arrow::RecordBatch> convertToArrow(const std::vector<std::string>& col_names,
+                                                     arrow::ipc::DictionaryMemo& memo) const;
   std::shared_ptr<const std::vector<std::string>> getDictionary(const int dict_id) const;
-  std::pair<std::vector<std::shared_ptr<arrow::Array>>, size_t> getArrowColumns(
-      const std::vector<std::shared_ptr<arrow::Field>>& fields) const;
+  std::shared_ptr<arrow::RecordBatch> getArrowBatch(const std::shared_ptr<arrow::Schema>& schema) const;
 
   ArrowResult getArrowCopyOnCpu(const std::vector<std::string>& col_names) const;
   ArrowResult getArrowCopyOnGpu(Data_Namespace::DataMgr* data_mgr,

--- a/QueryEngine/ResultSetConversion.cpp
+++ b/QueryEngine/ResultSetConversion.cpp
@@ -26,19 +26,17 @@
 #include <errno.h>
 #include <string>
 
-#include "arrow/array.h"
-#include "arrow/builder.h"
-#include "arrow/buffer.h"
+#include "arrow/api.h"
 #include "arrow/io/memory.h"
-#include "arrow/ipc/metadata.h"
-#include "arrow/ipc/reader.h"
-#include "arrow/ipc/writer.h"
-#include "arrow/pretty_print.h"
-#include "arrow/memory_pool.h"
-#include "arrow/type.h"
+#include "arrow/ipc/api.h"
+
+#include "ArrowUtil.h"
 
 #ifdef HAVE_CUDA
 #include <cuda.h>
+
+#include "arrow/gpu/cuda_api.h"
+
 #endif  // HAVE_CUDA
 #include <future>
 
@@ -154,41 +152,25 @@ void create_or_append_validity(const ScalarTargetValue& value,
 
 namespace arrow {
 
-#define ASSERT_OK(expr)           \
-  do {                            \
-    Status s = (expr);            \
-    if (!s.ok()) {                \
-      LOG(ERROR) << s.ToString(); \
-    }                             \
-  } while (0)
-
-#define RETURN_IF_NOT_OK(s) \
-  do {                      \
-    arrow::Status _s = (s); \
-    if (!_s.ok()) {         \
-      return nullptr;       \
-    }                       \
-  } while (0);
-
-TypePtr get_arrow_type(const SQLTypeInfo& mapd_type, const std::shared_ptr<Array>& dictionary) {
+static TypePtr get_arrow_type(const SQLTypeInfo& mapd_type, const std::shared_ptr<Array>& dict_values) {
   switch (get_physical_type(mapd_type)) {
     case kBOOLEAN:
-      return std::make_shared<BooleanType>();
+      return boolean();
     case kSMALLINT:
-      return std::make_shared<Int16Type>();
+      return int16();
     case kINT:
-      return std::make_shared<Int32Type>();
+      return int32();
     case kBIGINT:
-      return std::make_shared<Int64Type>();
+      return int64();
     case kFLOAT:
-      return std::make_shared<FloatType>();
+      return float32();
     case kDOUBLE:
-      return std::make_shared<DoubleType>();
+      return float64();
     case kTEXT:
       if (is_dict_enc_str(mapd_type)) {
-        CHECK(dictionary);
+        CHECK(dict_values);
         const auto index_type = get_arrow_type(get_dict_index_type_info(mapd_type), nullptr);
-        return std::make_shared<DictionaryType>(index_type, dictionary);
+        return dictionary(index_type, dict_values);
       }
     case kDECIMAL:
     case kNUMERIC:
@@ -206,264 +188,90 @@ TypePtr get_arrow_type(const SQLTypeInfo& mapd_type, const std::shared_ptr<Array
   return nullptr;
 }
 
+struct ColumnBuilder {
+  std::shared_ptr<Field> field;
+  std::unique_ptr<arrow::ArrayBuilder> builder;
+  SQLTypeInfo col_type;
+  SQLTypes physical_type;
+
+  void init(const SQLTypeInfo& col_type, const std::shared_ptr<Field>& field) {
+    this->field = field;
+
+    this->col_type = col_type;
+    this->physical_type = is_dict_enc_str(col_type) ? get_dict_index_type(col_type) : get_physical_type(col_type);
+
+    auto value_type = field->type();
+    if (value_type->id() == Type::DICTIONARY) {
+      value_type = static_cast<const DictionaryType&>(*value_type).index_type();
+    }
+    ARROW_THROW_NOT_OK(arrow::MakeBuilder(default_memory_pool(), value_type, &this->builder));
+  }
+
+  void reserve(size_t row_count) { ARROW_THROW_NOT_OK(builder->Reserve(static_cast<int64_t>(row_count))); }
+
+  template <typename BuilderType, typename C_TYPE>
+  inline void append_to_builder(const ValueArray& values, const std::shared_ptr<std::vector<bool>>& is_valid) {
+    const std::vector<C_TYPE>& vals = boost::get<std::vector<C_TYPE>>(values);
+
+    auto typed_builder = static_cast<BuilderType*>(this->builder.get());
+    if (this->field->nullable()) {
+      CHECK(is_valid.get());
+      ARROW_THROW_NOT_OK(typed_builder->Append(vals, *is_valid));
+    } else {
+      ARROW_THROW_NOT_OK(typed_builder->Append(vals));
+    }
+  }
+
+  std::shared_ptr<Array> finish() {
+    std::shared_ptr<Array> values;
+    ARROW_THROW_NOT_OK(this->builder->Finish(&values));
+    if (this->field->type()->id() == Type::DICTIONARY) {
+      return std::make_shared<DictionaryArray>(this->field->type(), values);
+    } else {
+      return values;
+    }
+  }
+
+  void append(const ValueArray& values, const std::shared_ptr<std::vector<bool>>& is_valid) {
+    switch (this->physical_type) {
+      case kBOOLEAN:
+        append_to_builder<BooleanBuilder, bool>(values, is_valid);
+        break;
+      case kSMALLINT:
+        append_to_builder<Int16Builder, int16_t>(values, is_valid);
+        break;
+      case kINT:
+        append_to_builder<Int32Builder, int32_t>(values, is_valid);
+        break;
+      case kBIGINT:
+        append_to_builder<Int64Builder, int64_t>(values, is_valid);
+        break;
+      case kFLOAT:
+        append_to_builder<FloatBuilder, float>(values, is_valid);
+        break;
+      case kDOUBLE:
+        append_to_builder<DoubleBuilder, double>(values, is_valid);
+        break;
+      default:
+        // TODO(miyu): support more scalar types.
+        CHECK(false);
+    }
+  }
+};
+
 std::shared_ptr<Field> make_field(const std::string name,
                                   const SQLTypeInfo& target_type,
                                   const std::shared_ptr<Array>& dictionary) {
-  return std::make_shared<Field>(name, get_arrow_type(target_type, dictionary), !target_type.get_notnull());
-}
-
-// Cited from arrow/test-util.h
-template <typename TYPE, typename C_TYPE>
-std::shared_ptr<Array> array_from_vector(const std::shared_ptr<std::vector<bool>> is_valid,
-                                         const std::vector<C_TYPE>& values) {
-  std::shared_ptr<Array> out;
-  MemoryPool* pool = default_memory_pool();
-  typename TypeTraits<TYPE>::BuilderType builder(pool);
-  if (is_valid) {
-    for (size_t i = 0; i < values.size(); ++i) {
-      if ((*is_valid)[i]) {
-        ASSERT_OK(builder.Append(values[i]));
-      } else {
-        ASSERT_OK(builder.AppendNull());
-      }
-    }
-  } else {
-    for (size_t i = 0; i < values.size(); ++i) {
-      ASSERT_OK(builder.Append(values[i]));
-    }
-  }
-  ASSERT_OK(builder.Finish(&out));
-  return out;
-}
-
-std::shared_ptr<Array> generate_column(const Field& field,
-                                       const std::shared_ptr<std::vector<bool>> is_valid,
-                                       const ValueArray& values) {
-  switch (field.type()->id()) {
-    case Type::BOOL: {
-      auto vals_bool = boost::get<std::vector<bool>>(&values);
-      CHECK(vals_bool);
-      return array_from_vector<BooleanType, bool>(is_valid, *vals_bool);
-    }
-    case Type::INT8: {
-      auto vals_i8 = boost::get<std::vector<int8_t>>(&values);
-      CHECK(vals_i8);
-      return array_from_vector<Int8Type, int8_t>(is_valid, *vals_i8);
-    }
-    case Type::INT16: {
-      auto vals_i16 = boost::get<std::vector<int16_t>>(&values);
-      CHECK(vals_i16);
-      return array_from_vector<Int16Type, int16_t>(is_valid, *vals_i16);
-    }
-    case Type::INT32: {
-      auto vals_i32 = boost::get<std::vector<int32_t>>(&values);
-      CHECK(vals_i32);
-      return array_from_vector<Int32Type, int32_t>(is_valid, *vals_i32);
-    }
-    case Type::INT64: {
-      auto vals_i64 = boost::get<std::vector<int64_t>>(&values);
-      CHECK(vals_i64);
-      return array_from_vector<Int64Type, int64_t>(is_valid, *vals_i64);
-    }
-    case Type::FLOAT: {
-      auto vals_float = boost::get<std::vector<float>>(&values);
-      CHECK(vals_float);
-      return array_from_vector<FloatType, float>(is_valid, *vals_float);
-    }
-    case Type::DOUBLE: {
-      auto vals_double = boost::get<std::vector<double>>(&values);
-      CHECK(vals_double);
-      return array_from_vector<DoubleType, double>(is_valid, *vals_double);
-    }
-    case Type::DICTIONARY: {
-      const auto dict_type = std::static_pointer_cast<DictionaryType>(field.type());
-      Field index_child(field.name(), dict_type->index_type(), field.nullable());
-      auto indices = generate_column(index_child, is_valid, values);
-      return std::make_shared<DictionaryArray>(dict_type, indices);
-    }
-    default:
-      CHECK(false);
-  }
-  return nullptr;
-}
-
-std::vector<std::shared_ptr<Array>> generate_columns(
-    const std::vector<std::shared_ptr<Field>>& fields,
-    const std::vector<std::shared_ptr<std::vector<bool>>>& null_bitmaps,
-    const std::vector<std::shared_ptr<ValueArray>>& column_values) {
-  const auto col_count = fields.size();
-  CHECK_GT(col_count, 0);
-  std::vector<std::shared_ptr<arrow::Array>> columns(col_count, nullptr);
-  auto generate = [&](const size_t i, std::shared_ptr<arrow::Array>& column) {
-    CHECK(column_values[i]);
-    column = generate_column(*fields[i], null_bitmaps[i], *column_values[i]);
-  };
-  if (col_count > 1) {
-    std::vector<std::future<void>> child_threads;
-    for (size_t col_idx = 0; col_idx < col_count; ++col_idx) {
-      child_threads.push_back(std::async(std::launch::async, generate, col_idx, std::ref(columns[col_idx])));
-    }
-    for (auto& child : child_threads) {
-      child.get();
-    }
-  } else {
-    generate(0, columns[0]);
-  }
-  return columns;
-}
-
-std::shared_ptr<ValueArray> create_value_array(const Field& field, const size_t value_count) {
-  const auto type_id = field.type()->id() == Type::DICTIONARY
-                           ? std::static_pointer_cast<DictionaryType>(field.type())->index_type()->id()
-                           : field.type()->id();
-  switch (type_id) {
-    case Type::BOOL: {
-      auto array = std::make_shared<ValueArray>(std::vector<bool>());
-      boost::get<std::vector<bool>>(*array).reserve(value_count);
-      return array;
-    }
-    case Type::INT8: {
-      auto array = std::make_shared<ValueArray>(std::vector<int8_t>());
-      boost::get<std::vector<int8_t>>(*array).reserve(value_count);
-      return array;
-    }
-    case Type::INT16: {
-      auto array = std::make_shared<ValueArray>(std::vector<int16_t>());
-      boost::get<std::vector<int16_t>>(*array).reserve(value_count);
-      return array;
-    }
-    case Type::INT32: {
-      auto array = std::make_shared<ValueArray>(std::vector<int32_t>());
-      boost::get<std::vector<int32_t>>(*array).reserve(value_count);
-      return array;
-    }
-    case Type::INT64: {
-      auto array = std::make_shared<ValueArray>(std::vector<int64_t>());
-      boost::get<std::vector<int64_t>>(*array).reserve(value_count);
-      return array;
-    }
-    case Type::FLOAT: {
-      auto array = std::make_shared<ValueArray>(std::vector<float>());
-      boost::get<std::vector<float>>(*array).reserve(value_count);
-      return array;
-    }
-    case Type::DOUBLE: {
-      auto array = std::make_shared<ValueArray>(std::vector<double>());
-      boost::get<std::vector<double>>(*array).reserve(value_count);
-      return array;
-    }
-    default:
-      CHECK(false);
-  }
-  return nullptr;
-}
-
-void append_value_array(ValueArray& dst, const ValueArray& src, const Field& field) {
-  const auto type_id = field.type()->id() == Type::DICTIONARY
-                           ? std::static_pointer_cast<DictionaryType>(field.type())->index_type()->id()
-                           : field.type()->id();
-  switch (type_id) {
-    case Type::BOOL: {
-      auto dst_bool = boost::get<std::vector<bool>>(&dst);
-      auto src_bool = boost::get<std::vector<bool>>(&src);
-      CHECK(dst_bool && src_bool);
-      dst_bool->insert(dst_bool->end(), src_bool->begin(), src_bool->end());
-    } break;
-    case Type::INT8: {
-      auto dst_i8 = boost::get<std::vector<int8_t>>(&dst);
-      auto src_i8 = boost::get<std::vector<int8_t>>(&src);
-      CHECK(dst_i8 && src_i8);
-      dst_i8->insert(dst_i8->end(), src_i8->begin(), src_i8->end());
-    } break;
-    case Type::INT16: {
-      auto dst_i16 = boost::get<std::vector<int16_t>>(&dst);
-      auto src_i16 = boost::get<std::vector<int16_t>>(&src);
-      CHECK(dst_i16 && src_i16);
-      dst_i16->insert(dst_i16->end(), src_i16->begin(), src_i16->end());
-    } break;
-    case Type::INT32: {
-      auto dst_i32 = boost::get<std::vector<int32_t>>(&dst);
-      auto src_i32 = boost::get<std::vector<int32_t>>(&src);
-      CHECK(dst_i32 && src_i32);
-      dst_i32->insert(dst_i32->end(), src_i32->begin(), src_i32->end());
-    } break;
-    case Type::INT64: {
-      auto dst_i64 = boost::get<std::vector<int64_t>>(&dst);
-      auto src_i64 = boost::get<std::vector<int64_t>>(&src);
-      CHECK(dst_i64 && src_i64);
-      dst_i64->insert(dst_i64->end(), src_i64->begin(), src_i64->end());
-    } break;
-    case Type::FLOAT: {
-      auto dst_flt = boost::get<std::vector<float>>(&dst);
-      auto src_flt = boost::get<std::vector<float>>(&src);
-      CHECK(dst_flt && src_flt);
-      dst_flt->insert(dst_flt->end(), src_flt->begin(), src_flt->end());
-    } break;
-    case Type::DOUBLE: {
-      auto dst_dbl = boost::get<std::vector<double>>(&dst);
-      auto src_dbl = boost::get<std::vector<double>>(&src);
-      CHECK(dst_dbl && src_dbl);
-      dst_dbl->insert(dst_dbl->end(), src_dbl->begin(), src_dbl->end());
-    } break;
-    default:
-      CHECK(false);
-      break;
-  }
-}
-
-std::shared_ptr<PoolBuffer> serialize_arrow_schema(const std::shared_ptr<Schema>& schema, ipc::DictionaryMemo& memo) {
-  auto buffer = std::make_shared<PoolBuffer>(default_memory_pool());
-  io::BufferOutputStream sink(buffer);
-  std::shared_ptr<ipc::RecordBatchStreamWriter> writer;
-  RETURN_IF_NOT_OK(ipc::RecordBatchStreamWriter::Open(&sink, schema, &writer));
-  writer->Close();
-  return buffer;
+  return field(name, get_arrow_type(target_type, dictionary), !target_type.get_notnull());
 }
 
 void print_serialized_schema(const uint8_t* data, const size_t length) {
-  const auto payload = std::make_shared<arrow::Buffer>(data, length);
-  auto buffer = std::make_shared<io::BufferReader>(payload);
-  std::shared_ptr<ipc::RecordBatchStreamReader> reader;
-  ipc::RecordBatchStreamReader::Open(buffer, &reader);
-  auto schema = reader->schema();
-  std::cout << "Schema: " << schema->ToString() << std::endl;
-  for (int i = 0; i < schema->num_fields(); ++i) {
-    std::shared_ptr<DictionaryType> dict_type = std::dynamic_pointer_cast<DictionaryType>(schema->field(i)->type());
-    if (!dict_type) {
-      continue;
-    }
-    PrettyPrint(*dict_type->dictionary(), 0, &std::cout);
-    std::cout << std::endl;
-  }
+  io::BufferReader reader(std::make_shared<arrow::Buffer>(data, length));
+  std::shared_ptr<Schema> schema;
+  ARROW_THROW_NOT_OK(ipc::ReadSchema(&reader, &schema));
 
-  std::shared_ptr<RecordBatch> batch;
-  reader->GetNextRecordBatch(&batch);
-  CHECK(!batch);
-}
-
-std::shared_ptr<PoolBuffer> serialize_arrow_records(const RecordBatch& rb) {
-  int64_t rb_sz = 0;
-  if (!rb.num_rows()) {
-    return std::make_shared<PoolBuffer>();
-  }
-  ASSERT_OK(ipc::GetRecordBatchSize(rb, &rb_sz));
-  auto pool = default_memory_pool();
-  auto buffer = std::make_shared<PoolBuffer>(pool);
-  buffer->Reserve(rb_sz);
-  io::BufferOutputStream sink(buffer);
-  // Frame of reference in file format is 0, see ARROW-384
-  const int64_t buffer_start_offset = 0;
-  const bool is_large_record = false;
-  ipc::FileBlock dummy_block{0, 0, 0};
-  RETURN_IF_NOT_OK(ipc::WriteRecordBatch(rb,
-                                         buffer_start_offset,
-                                         &sink,
-                                         &dummy_block.metadata_length,
-                                         &dummy_block.body_length,
-                                         pool,
-                                         kMaxNestingDepth,
-                                         is_large_record));
-  return buffer;
+  std::cout << "Arrow Schema: " << std::endl;
+  ARROW_THROW_NOT_OK(PrettyPrint(*schema, {}, &std::cout));
 }
 
 void print_serialized_records(const uint8_t* data, const size_t length, const std::shared_ptr<Schema>& schema) {
@@ -471,34 +279,13 @@ void print_serialized_records(const uint8_t* data, const size_t length, const st
     std::cout << "No row found" << std::endl;
     return;
   }
-
-  const auto payload = std::make_shared<arrow::Buffer>(data, length);
-  auto buffer_reader = std::make_shared<io::BufferReader>(payload);
-
-  std::shared_ptr<ipc::Message> message;
-  ReadMessage(buffer_reader.get(), &message);
-
-  // The buffer offsets start at 0, so we must construct a
-  // RandomAccessFile according to that frame of reference
-  std::shared_ptr<Buffer> body_payload;
-  buffer_reader->Read(message->body_length(), &body_payload);
-  io::BufferReader body_reader(body_payload);
-
   std::shared_ptr<RecordBatch> batch;
-  ipc::ReadRecordBatch(*message, schema, &body_reader, &batch);
 
-  for (int i = 0; i < batch->num_columns(); ++i) {
-    const auto& column = *batch->column(i);
-    std::cout << "Column #" << i << ": ";
-    PrettyPrint(column, 0, &std::cout);
-    std::cout << std::endl;
-  }
+  io::BufferReader buffer_reader(std::make_shared<arrow::Buffer>(data, length));
+  ARROW_THROW_NOT_OK(ipc::ReadRecordBatch(schema, &buffer_reader, &batch));
 }
 
-#undef RETURN_IF_NOT_OK
-#undef ASSERT_OK
-
-key_t get_and_copy_to_shm(const std::shared_ptr<PoolBuffer>& data) {
+key_t get_and_copy_to_shm(const std::shared_ptr<Buffer>& data) {
   if (!data->size()) {
     return IPC_PRIVATE;
   }
@@ -548,14 +335,22 @@ std::shared_ptr<const std::vector<std::string>> ResultSet::getDictionary(const i
   return sdp->getDictionary()->copyStrings();
 }
 
-std::pair<std::vector<std::shared_ptr<arrow::Array>>, size_t> ResultSet::getArrowColumns(
-    const std::vector<std::shared_ptr<arrow::Field>>& fields) const {
+std::shared_ptr<arrow::RecordBatch> ResultSet::getArrowBatch(const std::shared_ptr<arrow::Schema>& schema) const {
+  std::vector<std::shared_ptr<arrow::Array>> result_columns;
+
   const auto entry_count = entryCount();
   if (!entry_count) {
-    return {{}, 0};
+    return std::make_shared<arrow::RecordBatch>(schema, 0, result_columns);
   }
   const auto col_count = colCount();
   size_t row_count = 0;
+
+  std::vector<arrow::ColumnBuilder> builders(col_count);
+
+  // Create array builders
+  for (size_t i = 0; i < col_count; ++i) {
+    builders[i].init(getColType(i), schema->field(i));
+  }
 
   // TODO(miyu): speed up for columnar buffers
   auto fetch = [&](std::vector<std::shared_ptr<ValueArray>>& value_seg,
@@ -573,36 +368,34 @@ std::pair<std::vector<std::shared_ptr<arrow::Array>>, size_t> ResultSet::getArro
       }
       ++seg_row_count;
       for (size_t j = 0; j < col_count; ++j) {
-        const auto& col_type = getColType(j);
         auto scalar_value = boost::get<ScalarTargetValue>(&row[j]);
         // TODO(miyu): support more types other than scalar.
         CHECK(scalar_value);
-        const auto physical_type =
-            is_dict_enc_str(col_type) ? get_dict_index_type(col_type) : get_physical_type(col_type);
-        switch (physical_type) {
+        const auto& column = builders[j];
+        switch (column.physical_type) {
           case kBOOLEAN:
             create_or_append_value<bool, int64_t>(*scalar_value, value_seg[j], entry_count);
-            create_or_append_validity<int64_t>(*scalar_value, col_type, null_bitmap_seg[j], entry_count);
+            create_or_append_validity<int64_t>(*scalar_value, column.col_type, null_bitmap_seg[j], entry_count);
             break;
           case kSMALLINT:
             create_or_append_value<int16_t, int64_t>(*scalar_value, value_seg[j], entry_count);
-            create_or_append_validity<int64_t>(*scalar_value, col_type, null_bitmap_seg[j], entry_count);
+            create_or_append_validity<int64_t>(*scalar_value, column.col_type, null_bitmap_seg[j], entry_count);
             break;
           case kINT:
             create_or_append_value<int32_t, int64_t>(*scalar_value, value_seg[j], entry_count);
-            create_or_append_validity<int64_t>(*scalar_value, col_type, null_bitmap_seg[j], entry_count);
+            create_or_append_validity<int64_t>(*scalar_value, column.col_type, null_bitmap_seg[j], entry_count);
             break;
           case kBIGINT:
             create_or_append_value<int64_t, int64_t>(*scalar_value, value_seg[j], entry_count);
-            create_or_append_validity<int64_t>(*scalar_value, col_type, null_bitmap_seg[j], entry_count);
+            create_or_append_validity<int64_t>(*scalar_value, column.col_type, null_bitmap_seg[j], entry_count);
             break;
           case kFLOAT:
             create_or_append_value<float, float>(*scalar_value, value_seg[j], entry_count);
-            create_or_append_validity<float>(*scalar_value, col_type, null_bitmap_seg[j], entry_count);
+            create_or_append_validity<float>(*scalar_value, column.col_type, null_bitmap_seg[j], entry_count);
             break;
           case kDOUBLE:
             create_or_append_value<double, double>(*scalar_value, value_seg[j], entry_count);
-            create_or_append_validity<double>(*scalar_value, col_type, null_bitmap_seg[j], entry_count);
+            create_or_append_validity<double>(*scalar_value, column.col_type, null_bitmap_seg[j], entry_count);
             break;
           default:
             // TODO(miyu): support more scalar types.
@@ -636,67 +429,66 @@ std::pair<std::vector<std::shared_ptr<arrow::Array>>, size_t> ResultSet::getArro
     for (auto& child : child_threads) {
       row_count += child.get();
     }
-    for (size_t i = 0; i < fields.size(); ++i) {
-      column_values[i] = arrow::create_value_array(*fields[i], row_count);
-      if (fields[i]->nullable()) {
-        null_bitmaps[i] = std::make_shared<std::vector<bool>>();
-        null_bitmaps[i]->reserve(row_count);
-      }
+    for (int i = 0; i < schema->num_fields(); ++i) {
+      builders[i].reserve(row_count);
       for (size_t j = 0; j < cpu_count; ++j) {
         if (!column_value_segs[j][i]) {
           continue;
         }
-        arrow::append_value_array(*column_values[i], *column_value_segs[j][i], *fields[i]);
-        if (fields[i]->nullable()) {
-          CHECK(null_bitmap_segs[j][i]);
-          null_bitmaps[i]->insert(
-              null_bitmaps[i]->end(), null_bitmap_segs[j][i]->begin(), null_bitmap_segs[j][i]->end());
-        }
+        builders[i].append(*column_value_segs[j][i], null_bitmap_segs[j][i]);
       }
     }
   } else {
     row_count = fetch(column_values, null_bitmaps, size_t(0), entry_count);
+    for (int i = 0; i < schema->num_fields(); ++i) {
+      builders[i].reserve(row_count);
+      builders[i].append(*column_values[i], null_bitmaps[i]);
+    }
   }
 
-  return {row_count > 0 ? generate_columns(fields, null_bitmaps, column_values)
-                        : std::vector<std::shared_ptr<arrow::Array>>(),
-          row_count};
+  for (size_t i = 0; i < col_count; ++i) {
+    result_columns.push_back(builders[i].finish());
+  }
+  return std::make_shared<arrow::RecordBatch>(schema, row_count, result_columns);
 }
 
-arrow::RecordBatch ResultSet::convertToArrow(const std::vector<std::string>& col_names,
-                                             arrow::ipc::DictionaryMemo& memo) const {
+std::shared_ptr<arrow::RecordBatch> ResultSet::convertToArrow(const std::vector<std::string>& col_names,
+                                                              arrow::ipc::DictionaryMemo& memo) const {
   const auto col_count = colCount();
   std::vector<std::shared_ptr<arrow::Field>> fields;
   CHECK(col_names.empty() || col_names.size() == col_count);
   for (size_t i = 0; i < col_count; ++i) {
     const auto ti = getColType(i);
-    std::shared_ptr<arrow::Array> dict = nullptr;
+    std::shared_ptr<arrow::Array> dict;
     if (is_dict_enc_str(ti)) {
       const int dict_id = ti.get_comp_param();
       if (memo.HasDictionaryId(dict_id)) {
-        memo.GetDictionary(dict_id, &dict);
+        ARROW_THROW_NOT_OK(memo.GetDictionary(dict_id, &dict));
       } else {
         auto str_list = getDictionary(dict_id);
-        dict = arrow::array_from_vector<arrow::StringType, std::string>(nullptr, *str_list);
-        memo.AddDictionary(dict_id, dict);
+
+        arrow::StringBuilder builder;
+        for (const std::string& val : *str_list) {
+          ARROW_THROW_NOT_OK(builder.Append(val));
+        }
+        ARROW_THROW_NOT_OK(builder.Finish(&dict));
+        ARROW_THROW_NOT_OK(memo.AddDictionary(dict_id, dict));
       }
     }
     fields.push_back(arrow::make_field(col_names.empty() ? "" : col_names[i], ti, dict));
   }
-  auto schema = std::make_shared<arrow::Schema>(fields);
-  std::vector<std::shared_ptr<arrow::Array>> columns;
-  size_t row_count = 0;
-  if (col_count > 0) {
-    std::tie(columns, row_count) = getArrowColumns(fields);
-  }
-  return arrow::RecordBatch(schema, row_count, columns);
+  return getArrowBatch(arrow::schema(fields));
 }
 
 ResultSet::SerializedArrowOutput ResultSet::getSerializedArrowOutput(const std::vector<std::string>& col_names) const {
   arrow::ipc::DictionaryMemo dict_memo;
-  const auto arrow_copy = convertToArrow(col_names, dict_memo);
-  const auto serialized_schema = arrow::serialize_arrow_schema(arrow_copy.schema(), dict_memo);
-  const auto serialized_records = arrow::serialize_arrow_records(arrow_copy);
+  std::shared_ptr<arrow::RecordBatch> arrow_copy = convertToArrow(col_names, dict_memo);
+  std::shared_ptr<arrow::Buffer> serialized_records, serialized_schema;
+
+  ARROW_THROW_NOT_OK(
+      arrow::ipc::SerializeSchema(*arrow_copy->schema(), arrow::default_memory_pool(), &serialized_schema));
+
+  ARROW_THROW_NOT_OK(arrow::ipc::SerializeRecordBatch(*arrow_copy, arrow::default_memory_pool(), &serialized_records));
   return {serialized_schema, serialized_records};
 }
 

--- a/cmake/Modules/FindArrow.cmake
+++ b/cmake/Modules/FindArrow.cmake
@@ -50,6 +50,17 @@ find_library(Arrow_LIBRARY
   /usr/local/homebrew/lib
   /opt/local/lib)
 
+find_library(Arrow_GPU_LIBRARY
+  NAMES arrow_gpu
+  HINTS
+  ENV LD_LIBRARY_PATH
+  ENV DYLD_LIBRARY_PATH
+  PATHS
+  /usr/lib
+  /usr/local/lib
+  /usr/local/homebrew/lib
+  /opt/local/lib)
+
 get_filename_component(Arrow_LIBRARY_DIR ${Arrow_LIBRARY} DIRECTORY)
 
 if(Arrow_USE_STATIC_LIBS)
@@ -58,6 +69,7 @@ endif()
 
 # Set standard CMake FindPackage variables if found.
 set(Arrow_LIBRARIES ${Arrow_LIBRARY})
+set(Arrow_GPU_LIBRARIES ${Arrow_GPU_LIBRARY})
 set(Arrow_LIBRARY_DIRS ${Arrow_LIBRARY_DIR})
 set(Arrow_INCLUDE_DIRS ${Arrow_LIBRARY_DIR}/../include)
 

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# master as of 2017-09-07. Will want to update to 0.7.0 final as soon as it's
+# released
+ARROW_VERSION=6f27a6447171353427a129a5ce88dba181bd8af6
+
+function install_arrow() {
+  download https://github.com/apache/arrow/archive/$ARROW_VERSION.tar.gz
+  extract $ARROW_VERSION.tar.gz
+  mkdir -p arrow-$ARROW_VERSION/cpp/build
+  pushd arrow-$ARROW_VERSION/cpp/build
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DARROW_BUILD_SHARED=ON \
+    -DARROW_BUILD_STATIC=ON \
+    -DARROW_BUILD_TESTS=OFF \
+    -DARROW_BUILD_BENCHMARKS=OFF \
+    -DARROW_WITH_BROTLI=OFF \
+    -DARROW_WITH_ZLIB=OFF \
+    -DARROW_WITH_LZ4=OFF \
+    -DARROW_WITH_SNAPPY=OFF \
+    -DARROW_WITH_ZSTD=OFF \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DARROW_BOOST_USE_SHARED=off \
+    ..
+  make -j $(nproc)
+  make install
+  popd
+
+}

--- a/scripts/mapd-deps-centos.sh
+++ b/scripts/mapd-deps-centos.sh
@@ -14,6 +14,8 @@ $SUDO chown -R $USER $PREFIX
 export PATH=$PREFIX/bin:$PATH
 export LD_LIBRARY_PATH=$PREFIX/lib64:$PREFIX/lib:$LD_LIBRARY_PATH
 
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $SCRIPTS_DIR/common-functions.sh
 
 download() {
     wget --continue "$1"
@@ -263,23 +265,8 @@ popd
 download_make_install http://download.osgeo.org/proj/proj-4.9.3.tar.gz
 download_make_install http://download.osgeo.org/gdal/2.0.3/gdal-2.0.3.tar.xz "" "--without-curl --without-geos --with-libkml=$PREFIX --with-static-proj4=$PREFIX"
 
-# arrow
-VERS=0.4.1
-download https://github.com/apache/arrow/archive/apache-arrow-$VERS.tar.gz
-extract apache-arrow-$VERS.tar.gz
-mkdir -p arrow-apache-arrow-$VERS/cpp/build
-pushd arrow-apache-arrow-$VERS/cpp/build
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DARROW_BUILD_SHARED=off \
-    -DARROW_BUILD_STATIC=on \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DARROW_BOOST_USE_SHARED=off \
-    -DARROW_JEMALLOC_USE_SHARED=off \
-    ..
-makej
-make install
-popd
+# Apache Arrow (see common-functions.sh)
+install_arrow
 
 # https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz
 download https://internal-dependencies.mapd.com/thirdparty/go1.8.1.linux-amd64.tar.gz

--- a/scripts/mapd-deps-ubuntu.sh
+++ b/scripts/mapd-deps-ubuntu.sh
@@ -5,6 +5,9 @@ set -x
 
 PREFIX=/usr/local/mapd-deps
 
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $SCRIPTS_DIR/common-functions.sh
+
 sudo mkdir -p $PREFIX
 sudo chown -R $(id -u) $PREFIX
 
@@ -111,22 +114,8 @@ make -j $(nproc)
 make install
 popd
 
-VERS=0.4.1
-wget --continue https://github.com/apache/arrow/archive/apache-arrow-$VERS.tar.gz
-tar -xf apache-arrow-$VERS.tar.gz
-mkdir -p arrow-apache-arrow-$VERS/cpp/build
-pushd arrow-apache-arrow-$VERS/cpp/build
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DARROW_BUILD_SHARED=off \
-    -DARROW_BUILD_STATIC=on \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DARROW_BOOST_USE_SHARED=off \
-    -DARROW_JEMALLOC_USE_SHARED=off \
-    ..
-make -j $(nproc)
-make install
-popd
+# Apache Arrow (see common-functions.sh)
+install_arrow
 
 cat >> $PREFIX/mapd-deps.sh <<EOF
 PREFIX=$PREFIX


### PR DESCRIPTION
* Use up-to-date Arrow IPC serialization / read APIs
* Use vector appends with Arrow builders (cf ARROW-1468)
* Avoid extra full result set memory copy in multithreaded fetches
* Use library calls for pretty printing (cf ARROW-1396)