### PR TITLE
fixed NULL from loading decimal string like ".99"

### DIFF
--- a/Shared/Datum.cpp
+++ b/Shared/Datum.cpp
@@ -57,7 +57,8 @@ int64_t parse_numeric(const std::string& s, SQLTypeInfo& ti) {
   std::string before_dot;
   std::string after_dot;
   if (dot != std::string::npos) {
-    before_dot = s.substr(0, dot);
+    // make .99 as 0.99, or std::stoll below throws exception 'std::invalid_argument'
+    before_dot = (0 == dot)? "0": s.substr(0, dot);
     after_dot = s.substr(dot + 1);
   } else {
     before_dot = s;


### PR DESCRIPTION
Decimal constants without any digit before dot causes std::stoll to throws exception 'std::invalid_argument', making loaded decimal values become NULL.