### PR TITLE
ENH: Add RPC endpoint for loading serialized Arrow columnar payloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,13 +204,9 @@ include_directories(ThirdParty/googletest)
 add_subdirectory(ThirdParty/googletest)
 
 # Arrow
-option(ENABLE_ARROW_CONVERTER "Enable arrow converter" OFF)
-if(ENABLE_ARROW_CONVERTER)
-  find_package(Arrow REQUIRED)
-  add_definitions("-DENABLE_ARROW_CONVERTER")
-  add_definitions("-DARROW_NO_DEPRECATED_API")
-  include_directories(${Arrow_INCLUDE_DIRS})
-endif()
+find_package(Arrow REQUIRED)
+add_definitions("-DARROW_NO_DEPRECATED_API")
+include_directories(${Arrow_INCLUDE_DIRS})
 
 # RapidJSON
 include_directories(ThirdParty/rapidjson)
@@ -316,10 +312,7 @@ endif()
 
 list(APPEND MAPD_LIBRARIES Calcite)
 
-
-if(ENABLE_ARROW_CONVERTER)
-  list(APPEND MAPD_LIBRARIES ${Arrow_LIBRARIES})
-endif()
+list(APPEND MAPD_LIBRARIES ${Arrow_LIBRARIES})
 
 enable_testing()
 add_subdirectory(Tests)

--- a/Import/Importer.cpp
+++ b/Import/Importer.cpp
@@ -771,7 +771,6 @@ static void appendArrowBinary(const ColumnDescriptor* cd, const Array& values, s
 }  // namespace detail
 
 size_t TypedImportBuffer::add_arrow_values(const ColumnDescriptor* cd, const arrow::Array& col) {
-  size_t dataSize = 0;
   const auto type = cd->columnType.is_decimal() ? decimal_to_int_type(cd->columnType) : cd->columnType.get_type();
   if (cd->columnType.get_notnull()) {
     // We can't have any null values for this column; to have them is an error
@@ -818,7 +817,7 @@ size_t TypedImportBuffer::add_arrow_values(const ColumnDescriptor* cd, const arr
     default:
       throw std::runtime_error("Invalid Type");
   }
-  return dataSize;
+  return col.length();
 }
 
 size_t TypedImportBuffer::add_values(const ColumnDescriptor* cd, const TColumn& col) {

--- a/Import/Importer.cpp
+++ b/Import/Importer.cpp
@@ -49,6 +49,9 @@
 #include "gen-cpp/MapD.h"
 #include <vector>
 #include <iostream>
+
+#include <arrow/api.h>
+
 using std::ostream;
 
 namespace Importer_NS {
@@ -547,6 +550,118 @@ void TypedImportBuffer::pop_value() {
     default:
       CHECK(false);
   }
+}
+
+template <typename ArrayType, typename T>
+inline void appendArrowPrimitive(const arrow::Array& values, const T null_sentinel, std::vector<T>* buffer) {
+  const auto& typed_values = static_cast<const ArrayType&>(values);
+  buffer->reserve(typed_values.length());
+  for (int64_t i = 0; i < typed_values.length(); i++) {
+    if (typed_values.IsNull(i)) {
+      buffer->push_back(null_sentinel);
+    } else {
+      buffer->push_back(static_cast<T>(typed_values.Value(i)));
+    }
+  }
+}
+
+static void appendArrowBoolean(const ColumnDescriptor* cd, const arrow::Array& values, std::vector<int8_t>* buffer) {
+  CHECK(values.type_id() == arrow::Type::BOOL);
+  const int8_t null_sentinel = inline_fixed_encoding_null_val(cd->columnType);
+  appendArrowPrimitive<arrow::BooleanArray, int8_t>(values, null_sentinel, buffer);
+}
+
+static void appendArrowInt16(const ColumnDescriptor* cd, const arrow::Array& values, std::vector<int16_t>* buffer) {
+  CHECK(values.type_id() == arrow::Type::INT16);
+  const int16_t null_sentinel = inline_fixed_encoding_null_val(cd->columnType);
+  appendArrowPrimitive<arrow::Int16Array, int16_t>(values, null_sentinel, buffer);
+}
+
+static void appendArrowInt32(const ColumnDescriptor* cd, const arrow::Array& values, std::vector<int32_t>* buffer) {
+  CHECK(values.type_id() == arrow::Type::INT32);
+  const int32_t null_sentinel = inline_fixed_encoding_null_val(cd->columnType);
+  appendArrowPrimitive<arrow::Int32Array, int32_t>(values, null_sentinel, buffer);
+}
+
+static void appendArrowInt64(const ColumnDescriptor* cd, const arrow::Array& values, std::vector<int64_t>* buffer) {
+  CHECK(values.type_id() == arrow::Type::INT64);
+  const int64_t null_sentinel = inline_fixed_encoding_null_val(cd->columnType);
+  appendArrowPrimitive<arrow::Int64Array, int64_t>(values, null_sentinel, buffer);
+}
+
+static void appendArrowFloat(const ColumnDescriptor* cd, const arrow::Array& values, std::vector<float>* buffer) {
+  CHECK(values.type_id() == arrow::Type::FLOAT);
+  appendArrowPrimitive<arrow::FloatArray, float>(values, NULL_FLOAT, buffer);
+}
+
+static void appendArrowDouble(const ColumnDescriptor* cd, const arrow::Array& values, std::vector<double>* buffer) {
+  CHECK(values.type_id() == arrow::Type::DOUBLE);
+  appendArrowPrimitive<arrow::DoubleArray, double>(values, NULL_DOUBLE, buffer);
+}
+
+static void appendArrowBinary(const ColumnDescriptor* cd,
+                              const arrow::Array& values,
+                              std::vector<std::string>* buffer) {
+  const auto& typed_values = static_cast<const arrow::BinaryArray&>(values);
+  buffer->reserve(typed_values.length());
+
+  const char* bytes;
+  int32_t bytes_length = 0;
+  for (int64_t i = 0; i < typed_values.length(); i++) {
+    if (typed_values.IsNull(i)) {
+      // TODO(wesm): How are nulls handled for strings?
+      buffer->push_back(std::string());
+    } else {
+      bytes = reinterpret_cast<const char*>(typed_values.GetValue(i, &bytes_length));
+      buffer->push_back(std::string(bytes, bytes_length));
+    }
+  }
+}
+
+size_t TypedImportBuffer::add_arrow_values(const ColumnDescriptor* cd, const arrow::Array& col) {
+  size_t dataSize = 0;
+  const auto type = cd->columnType.is_decimal() ? decimal_to_int_type(cd->columnType) : cd->columnType.get_type();
+  if (cd->columnType.get_notnull()) {
+    // We can't have any null values for this column; to have them is an error
+    if (col.null_count() > 0) {
+      throw std::runtime_error("NULL not allowed for column " + cd->columnName);
+    }
+  }
+
+  switch (type) {
+    case kBOOLEAN:
+      appendArrowBoolean(cd, col, bool_buffer_);
+      break;
+    case kSMALLINT:
+      appendArrowInt16(cd, col, smallint_buffer_);
+      break;
+    case kINT:
+      appendArrowInt32(cd, col, int_buffer_);
+      break;
+    case kBIGINT:
+      appendArrowInt64(cd, col, bigint_buffer_);
+      break;
+    case kFLOAT:
+      appendArrowFloat(cd, col, float_buffer_);
+      break;
+    case kDOUBLE:
+      appendArrowDouble(cd, col, double_buffer_);
+      break;
+    case kTEXT:
+    case kVARCHAR:
+    case kCHAR:
+      appendArrowBinary(cd, col, string_buffer_);
+      break;
+    case kTIME:
+    case kTIMESTAMP:
+    case kDATE:
+      throw std::runtime_error("Arrow date/time type appends not yet supported");
+    case kARRAY:
+      throw std::runtime_error("Arrow array appends not yet supported");
+    default:
+      throw std::runtime_error("Invalid Type");
+  }
+  return dataSize;
 }
 
 size_t TypedImportBuffer::add_values(const ColumnDescriptor* cd, const TColumn& col) {

--- a/Import/Importer.h
+++ b/Import/Importer.h
@@ -47,6 +47,12 @@
 class TDatum;
 class TColumn;
 
+namespace arrow {
+
+class Array;
+
+}  // namespace arrow
+
 namespace Importer_NS {
 
 enum class TableType { DELIMITED, POLYGON };
@@ -419,6 +425,9 @@ class TypedImportBuffer : boost::noncopyable {
   }
 
   size_t add_values(const ColumnDescriptor* cd, const TColumn& data);
+
+  size_t add_arrow_values(const ColumnDescriptor* cd, const arrow::Array& data);
+
   void add_value(const ColumnDescriptor* cd, const std::string& val, const bool is_null, const CopyParams& copy_params);
   void add_value(const ColumnDescriptor* cd, const TDatum& val, const bool is_null);
   void pop_value();

--- a/QueryEngine/ArrowResultSet.cpp
+++ b/QueryEngine/ArrowResultSet.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef ENABLE_ARROW_CONVERTER
 #include "ArrowResultSet.h"
 #include "ArrowUtil.h"
 #include "RelAlgExecutionDescriptor.h"
@@ -171,5 +170,3 @@ std::unique_ptr<ArrowResultSet> result_set_arrow_loopback(const ExecutionResult&
 
   return boost::make_unique<ArrowResultSet>(batch);
 }
-
-#endif  // ENABLE_ARROW_CONVERTER

--- a/QueryEngine/ArrowResultSet.cpp
+++ b/QueryEngine/ArrowResultSet.cpp
@@ -54,7 +54,7 @@ ArrowResultSet::ArrowResultSet(const std::shared_ptr<arrow::RecordBatch>& record
     std::shared_ptr<arrow::Field> field = schema->field(i);
     SQLTypeInfo type_info = type_from_arrow_field(*schema->field(i));
     column_metainfo_.emplace_back(field->name(), type_info);
-    columns_.emplace_back(std::move(record_batch->column(i)));
+    columns_.emplace_back(record_batch->column(i));
   }
 }
 

--- a/QueryEngine/ArrowUtil.cpp
+++ b/QueryEngine/ArrowUtil.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef ENABLE_ARROW_CONVERTER
 #include "ArrowUtil.h"
 #include "DataMgr/BufferMgr/BufferMgr.h"  // for OutOfMemory
 
@@ -31,4 +30,3 @@ void arrow_status_throw(const ::arrow::Status& s) {
       throw std::runtime_error(message);
   }
 }
-#endif  // ENABLE_ARROW_CONVERTER

--- a/QueryEngine/ArrowUtil.h
+++ b/QueryEngine/ArrowUtil.h
@@ -23,6 +23,7 @@
 #include "Shared/likely.h"
 
 void arrow_status_throw(const ::arrow::Status& s);
+void arrow_status_thrift_throw(const ::arrow::Status& s);
 
 #define ARROW_THROW_NOT_OK(s) \
   do {                        \

--- a/QueryEngine/CMakeLists.txt
+++ b/QueryEngine/CMakeLists.txt
@@ -143,9 +143,7 @@ else()
   add_library(QueryEngine ${query_engine_source_files})
 endif()
 
-if(ENABLE_ARROW_CONVERTER)
-  set(ARROW_LIBS ${Arrow_LIBRARIES})
-endif()
+set(ARROW_LIBS ${Arrow_LIBRARIES})
 
 if(ENABLE_RENDERING)
   target_link_libraries(QueryEngine CsvImport Planner StringDictionary Utils QueryRenderer ${ARROW_LIBS})

--- a/QueryEngine/ResultSet.h
+++ b/QueryEngine/ResultSet.h
@@ -30,15 +30,8 @@
 #include "TargetValue.h"
 #include "../Chunk/Chunk.h"
 
-#ifdef ENABLE_ARROW_CONVERTER
 #include "arrow/api.h"
 #include "arrow/ipc/api.h"
-// Arrow defines macro UNUSED conflict w/ that in jni_md.h
-#ifdef UNUSED
-#undef UNUSED
-#endif
-#include "arrow/type.h"
-#endif
 
 #include <atomic>
 #include <functional>
@@ -205,14 +198,12 @@ struct OneIntegerColumnRow {
   const bool valid;
 };
 
-#ifdef ENABLE_ARROW_CONVERTER
 struct ArrowResult {
   std::vector<char> sm_handle;
   int64_t sm_size;
   std::vector<char> df_handle;
   int64_t df_size;
 };
-#endif
 
 class TSerializedRows;
 
@@ -347,7 +338,6 @@ class ResultSet {
 
   static std::unique_ptr<ResultSet> unserialize(const std::string&, const Executor*);
 
-#ifdef ENABLE_ARROW_CONVERTER
   struct SerializedArrowOutput {
     std::shared_ptr<arrow::Buffer> schema;
     std::shared_ptr<arrow::Buffer> records;
@@ -359,7 +349,6 @@ class ResultSet {
                            const ExecutorDeviceType device_type,
                            const size_t device_id,
                            const std::vector<std::string>& col_names) const;
-#endif  // ENABLE_ARROW_CONVERTER
 
  private:
   std::vector<TargetValue> getNextRowImpl(const bool translate_strings, const bool decimal_to_double) const;
@@ -468,7 +457,6 @@ class ResultSet {
 
   int getGpuCount() const;
 
-#ifdef ENABLE_ARROW_CONVERTER
   std::shared_ptr<arrow::RecordBatch> convertToArrow(const std::vector<std::string>& col_names,
                                                      arrow::ipc::DictionaryMemo& memo) const;
   std::shared_ptr<const std::vector<std::string>> getDictionary(const int dict_id) const;
@@ -478,7 +466,6 @@ class ResultSet {
   ArrowResult getArrowCopyOnGpu(Data_Namespace::DataMgr* data_mgr,
                                 const size_t device_id,
                                 const std::vector<std::string>& col_names) const;
-#endif
 
   std::string serializeProjection() const;
 

--- a/QueryEngine/ResultSetConversion.cpp
+++ b/QueryEngine/ResultSetConversion.cpp
@@ -17,7 +17,6 @@
 #include "ResultSet.h"
 #include "Execute.h"
 
-#ifdef ENABLE_ARROW_CONVERTER
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -564,5 +563,3 @@ ArrowResult ResultSet::getArrowCopy(Data_Namespace::DataMgr* data_mgr,
   CHECK(device_type == ExecutorDeviceType::GPU);
   return getArrowCopyOnGpu(data_mgr, device_id, col_names);
 }
-
-#endif  // ENABLE_ARROW_CONVERTER

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ The following `cmake`/`ccmake` options can enable/disable different features:
 - `-DMAPD_IMMERSE_DOWNLOAD=on` download the latest master build of Immerse / `mapd2-frontend`. Default `on`.
 - `-DMAPD_DOCS_DOWNLOAD=on` download the latest master build of the documentation / `docs.mapd.com`. Default `off`. Note: this is a >50MB download.
 - `-DPREFER_STATIC_LIBS=on` static link dependencies, if available. Default `off`.
-- `-DENABLE_ARROW_CONVERTER=on` enable alpha support for the [GPU Data Frame](https://github.com/gpuopenanalytics), based on a subset of the [Apache Arrow specification](http://arrow.apache.org/). Default `off`.
 
 # Testing
 

--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -17,9 +17,7 @@
 #include "QueryRunner.h"
 
 #include "../Parser/parser.h"
-#ifdef ENABLE_ARROW_CONVERTER
 #include "../QueryEngine/ArrowResultSet.h"
-#endif  // ENABLE_ARROW_CONVERTER
 #include "../SqliteConnector/SqliteConnector.h"
 #include "../Import/Importer.h"
 
@@ -130,7 +128,6 @@ class SQLiteComparator {
     compare_impl(mapd_results.get(), query_string, device_type, false);
   }
 
-#ifdef ENABLE_ARROW_CONVERTER
   void compare_arrow_output(const std::string& query_string,
                             const std::string& sqlite_query_string,
                             const ExecutorDeviceType device_type) {
@@ -138,7 +135,6 @@ class SQLiteComparator {
     const auto arrow_mapd_results = result_set_arrow_loopback(results);
     compare_impl(arrow_mapd_results.get(), sqlite_query_string, device_type, false);
   }
-#endif  // ENABLE_ARROW_CONVERTER
 
   void compare(const std::string& query_string,
                const std::string& sqlite_query_string,
@@ -349,11 +345,10 @@ void cta(const std::string& query_string, const ExecutorDeviceType device_type) 
   g_sqlite_comparator.compare_timstamp_approx(query_string, device_type);
 }
 
-#ifdef ENABLE_ARROW_CONVERTER
 void c_arrow(const std::string& query_string, const ExecutorDeviceType device_type) {
   g_sqlite_comparator.compare_arrow_output(query_string, query_string, device_type);
 }
-#endif  // ENABLE_ARROW_CONVERTER
+
 }  // namespace
 
 #define SKIP_NO_GPU()                                        \
@@ -3607,7 +3602,6 @@ TEST(Select, DesugarTransform) {
   }
 }
 
-#ifdef ENABLE_ARROW_CONVERTER
 TEST(Select, ArrowOutput) {
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
@@ -3616,7 +3610,6 @@ TEST(Select, ArrowOutput) {
     c_arrow("SELECT null_str, COUNT(*) FROM test GROUP BY null_str;", dt);
   }
 }
-#endif  // ENABLE_ARROW_CONVERTER
 
 TEST(Select, WatchdogTest) {
   g_enable_watchdog = true;

--- a/ThriftHandler/MapDHandler.cpp
+++ b/ThriftHandler/MapDHandler.cpp
@@ -1129,8 +1129,12 @@ void MapDHandler::load_table_binary_arrow(const TSessionId& session,
   RecordBatchVector batches = loadArrowStream(arrow_stream);
 
   // Assuming have one batch for now
-  if (batches.size() == 1) {
-    LOG(ERROR) << "Expected a single Arrow record batch. Import aborted";
+  if (batches.size() != 1) {
+    std::string msg = "Expected a single Arrow record batch. Import aborted";
+    LOG(ERROR) << msg;
+    TMapDException ex;
+    ex.error_msg = msg;
+    throw ex;
   }
 
   std::shared_ptr<arrow::RecordBatch> batch = batches[0];

--- a/ThriftHandler/MapDHandler.h
+++ b/ThriftHandler/MapDHandler.h
@@ -158,6 +158,13 @@ class MapDHandler : public MapDIf {
   void get_version(std::string& _return);
   void get_memory(std::vector<TNodeMemoryInfo>& _return, const TSessionId& session, const std::string& memory_level);
   void load_table_binary(const TSessionId& session, const std::string& table_name, const std::vector<TRow>& rows);
+
+  void prepare_columnar_loader(const TSessionId& session,
+                               const std::string& table_name,
+                               size_t num_cols,
+                               std::unique_ptr<Importer_NS::Loader>* loader,
+                               std::vector<std::unique_ptr<Importer_NS::TypedImportBuffer>>* import_buffers);
+
   void load_table_binary_columnar(const TSessionId& session,
                                   const std::string& table_name,
                                   const std::vector<TColumn>& cols);

--- a/ThriftHandler/MapDHandler.h
+++ b/ThriftHandler/MapDHandler.h
@@ -161,6 +161,10 @@ class MapDHandler : public MapDIf {
   void load_table_binary_columnar(const TSessionId& session,
                                   const std::string& table_name,
                                   const std::vector<TColumn>& cols);
+  void load_table_binary_arrow(const TSessionId& session,
+                               const std::string& table_name,
+                               const std::string& arrow_stream);
+
   void load_table(const TSessionId& session, const std::string& table_name, const std::vector<TStringRow>& rows);
   void render(TRenderResult& _return,
               const TSessionId& session,
@@ -310,14 +314,12 @@ class MapDHandler : public MapDIf {
                        const int32_t first_n,
                        const bool just_explain,
                        const bool just_validate) const;
-#ifdef ENABLE_ARROW_CONVERTER
   void execute_rel_alg_df(TDataFrame& _return,
                           const std::string& query_ra,
                           const Catalog_Namespace::SessionInfo& session_info,
                           const ExecutorDeviceType device_type,
                           const size_t device_id,
                           const int32_t first_n) const;
-#endif
   TColumnType populateThriftColumnType(const Catalog_Namespace::Catalog* cat, const ColumnDescriptor* cd);
   TRowDescriptor fixup_row_descriptor(const TRowDescriptor& row_desc, const Catalog_Namespace::Catalog& cat);
   void set_execution_mode_nolock(Catalog_Namespace::SessionInfo* session_ptr, const TExecuteMode::type mode);
@@ -361,11 +363,8 @@ class MapDHandler : public MapDIf {
   std::vector<TargetMetaInfo> getTargetMetaInfo(
       const std::vector<std::shared_ptr<Analyzer::TargetEntry>>& targets) const;
 
-#ifdef ENABLE_ARROW_CONVERTER
   std::vector<std::string> getTargetNames(const std::vector<TargetMetaInfo>& targets) const;
-
   std::vector<std::string> getTargetNames(const std::vector<std::shared_ptr<Analyzer::TargetEntry>>& targets) const;
-#endif
 
   void render_root_plan(TRenderResult& _return,
                         Planner::RootPlan* root_plan,

--- a/mapd.thrift
+++ b/mapd.thrift
@@ -379,7 +379,7 @@ service MapD {
   # import
   void load_table_binary(1: TSessionId session, 2: string table_name, 3: list<TRow> rows) throws (1: TMapDException e)
   void load_table_binary_columnar(1: TSessionId session, 2: string table_name, 3: list<TColumn> cols) throws (1: TMapDException e)
-  void load_table_binary_arrow(1: TSessionId session, 2: string table_name, 3: string arrow_stream) throws (1: TMapDException e)
+  void load_table_binary_arrow(1: TSessionId session, 2: string table_name, 3: binary arrow_stream) throws (1: TMapDException e)
   void load_table(1: TSessionId session, 2: string table_name, 3: list<TStringRow> rows) throws (1: TMapDException e)
   TDetectResult detect_column_types(1: TSessionId session, 2: string file_name, 3: TCopyParams copy_params) throws (1: TMapDException e)
   void create_table(1: TSessionId session, 2: string table_name, 3: TRowDescriptor row_desc, 4: TTableType table_type=TTableType.DELIMITED) throws (1: TMapDException e)

--- a/mapd.thrift
+++ b/mapd.thrift
@@ -379,6 +379,7 @@ service MapD {
   # import
   void load_table_binary(1: TSessionId session, 2: string table_name, 3: list<TRow> rows) throws (1: TMapDException e)
   void load_table_binary_columnar(1: TSessionId session, 2: string table_name, 3: list<TColumn> cols) throws (1: TMapDException e)
+  void load_table_binary_arrow(1: TSessionId session, 2: string table_name, 3: string arrow_stream) throws (1: TMapDException e)
   void load_table(1: TSessionId session, 2: string table_name, 3: list<TStringRow> rows) throws (1: TMapDException e)
   TDetectResult detect_column_types(1: TSessionId session, 2: string file_name, 3: TCopyParams copy_params) throws (1: TMapDException e)
   void create_table(1: TSessionId session, 2: string table_name, 3: TRowDescriptor row_desc, 4: TTableType table_type=TTableType.DELIMITED) throws (1: TMapDException e)

--- a/scripts/common-functions.sh
+++ b/scripts/common-functions.sh
@@ -27,9 +27,7 @@ function download_make_install() {
     popd
 }
 
-# master as of 2017-09-07. Will want to update to 0.7.0 final as soon as it's
-# released
-ARROW_VERSION=6f27a6447171353427a129a5ce88dba181bd8af6
+ARROW_VERSION=apache-arrow-0.7.0
 
 function install_arrow() {
   download https://github.com/apache/arrow/archive/$ARROW_VERSION.tar.gz


### PR DESCRIPTION
There's some code duplication with the `load_table_binary_columnar`, but I don't have enough context about other parts of the system to know the best way to refactor. 

Some TODO

- [x] e2e testing with pymapd. Sanitize / cast types on client side for now
- [x] Throw exceptions instead of aborting when an Arrow column type is incorrect
- [x] check performance vs. load_table_binary_columnar from pymapd

This also makes Arrow a required build dependency

Close #89 