### PR TITLE
import: fix DECIMAL import for values -1 < val < 0

### DIFF
--- a/Shared/Datum.cpp
+++ b/Shared/Datum.cpp
@@ -64,8 +64,10 @@ int64_t parse_numeric(const std::string& s, SQLTypeInfo& ti) {
     before_dot = s;
     after_dot = "0";
   }
+  const bool is_negative = before_dot.find_first_of('-', 0) != std::string::npos;
+  const int64_t sign = is_negative ? -1 : 1;
   int64_t result;
-  result = std::stoll(before_dot);
+  result = std::abs(std::stoll(before_dot));
   int64_t fraction = 0;
   if (!after_dot.empty())
     fraction = std::stoll(after_dot);
@@ -88,7 +90,7 @@ int64_t parse_numeric(const std::string& s, SQLTypeInfo& ti) {
     result -= fraction;
   else
     result += fraction;
-  return result;
+  return result * sign;
 }
 
 // had to port timegm because the one on MacOS is horrendously slow.


### PR DESCRIPTION
parse_numeric did not explicitly handle negative values, which would
cause the negative to be dropped if the before_dot value was `-0`.

Resolves #98