### PR TITLE
 Fix a heap corruption

### DIFF
--- a/Shared/Datum.cpp
+++ b/Shared/Datum.cpp
@@ -57,7 +57,8 @@ int64_t parse_numeric(const std::string& s, SQLTypeInfo& ti) {
   std::string before_dot;
   std::string after_dot;
   if (dot != std::string::npos) {
-    before_dot = s.substr(0, dot);
+    // make .99 as 0.99, or std::stoll below throws exception 'std::invalid_argument'
+    before_dot = (0 == dot)? "0": s.substr(0, dot);
     after_dot = s.substr(dot + 1);
   } else {
     before_dot = s;


### PR DESCRIPTION
Fix heap corruption from unexpected file read after running out of cpu buffers and Buffer::reserve() has failed with SlabTooBig exception