### PR TITLE
Implemented optional error percentage argument for APPROX_COUNT_DISTINCT

### DIFF
--- a/Analyzer/Analyzer.cpp
+++ b/Analyzer/Analyzer.cpp
@@ -127,7 +127,7 @@ std::shared_ptr<Analyzer::Expr> LikelihoodExpr::deep_copy() const {
   return makeExpr<LikelihoodExpr>(arg->deep_copy(), likelihood);
 }
 std::shared_ptr<Analyzer::Expr> AggExpr::deep_copy() const {
-  return makeExpr<AggExpr>(type_info, aggtype, arg == nullptr ? nullptr : arg->deep_copy(), is_distinct);
+  return makeExpr<AggExpr>(type_info, aggtype, arg == nullptr ? nullptr : arg->deep_copy(), is_distinct, error_rate);
 }
 
 std::shared_ptr<Analyzer::Expr> CaseExpr::deep_copy() const {
@@ -1376,7 +1376,8 @@ std::shared_ptr<Analyzer::Expr> AggExpr::rewrite_with_targetlist(
 
 std::shared_ptr<Analyzer::Expr> AggExpr::rewrite_with_child_targetlist(
     const std::vector<std::shared_ptr<TargetEntry>>& tlist) const {
-  return makeExpr<AggExpr>(type_info, aggtype, arg ? arg->rewrite_with_child_targetlist(tlist) : nullptr, is_distinct);
+  return makeExpr<AggExpr>(
+      type_info, aggtype, arg ? arg->rewrite_with_child_targetlist(tlist) : nullptr, is_distinct, error_rate);
 }
 
 std::shared_ptr<Analyzer::Expr> AggExpr::rewrite_agg_to_var(

--- a/Analyzer/Analyzer.h
+++ b/Analyzer/Analyzer.h
@@ -761,17 +761,23 @@ class LikelihoodExpr : public Expr {
  */
 class AggExpr : public Expr {
  public:
-  AggExpr(const SQLTypeInfo& ti, SQLAgg a, std::shared_ptr<Analyzer::Expr> g, bool d)
-      : Expr(ti, true), aggtype(a), arg(g), is_distinct(d) {}
-  AggExpr(SQLTypes t, SQLAgg a, Expr* g, bool d, int idx)
+  AggExpr(const SQLTypeInfo& ti,
+          SQLAgg a,
+          std::shared_ptr<Analyzer::Expr> g,
+          bool d,
+          std::shared_ptr<Analyzer::Constant> e)
+      : Expr(ti, true), aggtype(a), arg(g), is_distinct(d), error_rate(e) {}
+  AggExpr(SQLTypes t, SQLAgg a, Expr* g, bool d, std::shared_ptr<Analyzer::Constant> e, int idx)
       : Expr(SQLTypeInfo(t, g == nullptr ? true : g->get_type_info().get_notnull()), true),
         aggtype(a),
         arg(g),
-        is_distinct(d) {}
+        is_distinct(d),
+        error_rate(e) {}
   SQLAgg get_aggtype() const { return aggtype; }
   Expr* get_arg() const { return arg.get(); }
   std::shared_ptr<Analyzer::Expr> get_own_arg() const { return arg; }
   bool get_is_distinct() const { return is_distinct; }
+  std::shared_ptr<Analyzer::Constant> get_error_rate() const { return error_rate; }
   virtual std::shared_ptr<Analyzer::Expr> deep_copy() const;
   virtual void group_predicates(std::list<const Expr*>& scan_predicates,
                                 std::list<const Expr*>& join_predicates,
@@ -796,9 +802,10 @@ class AggExpr : public Expr {
   virtual void find_expr(bool (*f)(const Expr*), std::list<const Expr*>& expr_list) const;
 
  private:
-  SQLAgg aggtype;                       // aggregate type: kAVG, kMIN, kMAX, kSUM, kCOUNT
-  std::shared_ptr<Analyzer::Expr> arg;  // argument to aggregate
-  bool is_distinct;                     // true only if it is for COUNT(DISTINCT x).
+  SQLAgg aggtype;                                  // aggregate type: kAVG, kMIN, kMAX, kSUM, kCOUNT
+  std::shared_ptr<Analyzer::Expr> arg;             // argument to aggregate
+  bool is_distinct;                                // true only if it is for COUNT(DISTINCT x)
+  std::shared_ptr<Analyzer::Constant> error_rate;  // error rate of kAPPROX_COUNT_DISTINCT
 };
 
 /*

--- a/Parser/ParserNode.cpp
+++ b/Parser/ParserNode.cpp
@@ -642,7 +642,7 @@ std::shared_ptr<Analyzer::Expr> FunctionRef::analyze(const Catalog_Namespace::Ca
   }
   int naggs = query.get_num_aggs();
   query.set_num_aggs(naggs + 1);
-  return makeExpr<Analyzer::AggExpr>(result_type, agg_type, arg_expr, is_distinct);
+  return makeExpr<Analyzer::AggExpr>(result_type, agg_type, arg_expr, is_distinct, nullptr);
 }
 
 std::shared_ptr<Analyzer::Expr> CastExpr::analyze(const Catalog_Namespace::Catalog& catalog,

--- a/QueryEngine/CalciteAdapter.cpp
+++ b/QueryEngine/CalciteAdapter.cpp
@@ -31,18 +31,13 @@
 
 namespace {
 
-std::vector<size_t> get_agg_operand_idxs(const rapidjson::Value& expr) {
+ssize_t get_agg_operand_idx(const rapidjson::Value& expr) {
   CHECK(expr.IsObject());
   CHECK(expr.HasMember("agg"));
   const auto& agg_operands = expr["operands"];
   CHECK(agg_operands.IsArray());
-  auto n_operands = agg_operands.Size();
-  CHECK(n_operands <= 2);
-  std::vector<size_t> operands;
-  for (size_t i = 0; i < n_operands; ++i) {
-    operands.push_back(agg_operands[i].GetInt());
-  }
-  return operands;
+  CHECK(agg_operands.Size() <= 2);
+  return agg_operands.Empty() ? -1 : agg_operands[0].GetInt();
 }
 
 std::tuple<const rapidjson::Value*, SQLTypeInfo, SQLTypeInfo> parse_literal(const rapidjson::Value& expr) {
@@ -457,20 +452,14 @@ class CalciteAdapter {
     CHECK(expr_type.IsObject());
     const auto agg_kind = to_agg_kind(expr["agg"].GetString());
     const bool is_distinct = expr["distinct"].GetBool();
-    const auto operands = get_agg_operand_idxs(expr);
-    std::shared_ptr<Analyzer::Expr> arg_expr{nullptr};
-    std::shared_ptr<Analyzer::Constant> err_rate_expr{nullptr};
-    if (operands.size() >= 1) {
-      CHECK_LT(operands[0], scan_targets.size());
-      arg_expr = scan_targets[operands[0]]->get_own_expr();
-      if (operands.size() == 2) {
-        CHECK_LT(operands[1], scan_targets.size());
-        err_rate_expr = std::dynamic_pointer_cast<Analyzer::Constant>(scan_targets[operands[1]]->get_own_expr());
-        CHECK(err_rate_expr != nullptr);
-      }
+    const auto operand = get_agg_operand_idx(expr);
+    const bool takes_arg{operand >= 0};
+    if (takes_arg) {
+      CHECK_LT(operand, static_cast<ssize_t>(scan_targets.size()));
     }
+    const auto arg_expr = takes_arg ? scan_targets[operand]->get_own_expr() : nullptr;
     const auto agg_ti = get_agg_type(agg_kind, arg_expr.get());
-    return makeExpr<Analyzer::AggExpr>(agg_ti, agg_kind, arg_expr, is_distinct, err_rate_expr);
+    return makeExpr<Analyzer::AggExpr>(agg_ti, agg_kind, arg_expr, is_distinct, nullptr);
   }
 
   std::shared_ptr<Analyzer::Expr> translateTypedLiteral(const rapidjson::Value& expr) {

--- a/QueryEngine/ExpressionRewrite.cpp
+++ b/QueryEngine/ExpressionRewrite.cpp
@@ -224,7 +224,8 @@ class DeepCopyVisitor : public ScalarExprVisitor<std::shared_ptr<Analyzer::Expr>
 
   RetType visitAggExpr(const Analyzer::AggExpr* agg) const override {
     RetType arg = agg->get_arg() ? visit(agg->get_arg()) : nullptr;
-    return makeExpr<Analyzer::AggExpr>(agg->get_type_info(), agg->get_aggtype(), arg, agg->get_is_distinct());
+    return makeExpr<Analyzer::AggExpr>(
+        agg->get_type_info(), agg->get_aggtype(), arg, agg->get_is_distinct(), agg->get_error_rate());
   }
 };
 

--- a/QueryEngine/GroupByAndAggregate.cpp
+++ b/QueryEngine/GroupByAndAggregate.cpp
@@ -2280,9 +2280,9 @@ CountDistinctDescriptors GroupByAndAggregate::initCountDistinctDescriptors() {
       if (agg_info.agg_kind == kAPPROX_COUNT_DISTINCT) {
         const auto error_rate = agg_expr->get_error_rate();
         if (error_rate) {
-          CHECK(error_rate->get_type_info().is_integer());
-          CHECK_GE(error_rate->get_constval().intval, 1);
-          bitmap_sz_bits = hll_sz_for_rate(error_rate->get_constval().intval);
+          CHECK(error_rate->get_type_info().get_type() == kSMALLINT);
+          CHECK_GE(error_rate->get_constval().smallintval, 1);
+          bitmap_sz_bits = hll_size_for_rate(error_rate->get_constval().smallintval);
         } else {
           bitmap_sz_bits = g_hll_precision_bits;
         }

--- a/QueryEngine/HyperLogLog.h
+++ b/QueryEngine/HyperLogLog.h
@@ -74,10 +74,10 @@ inline void hll_unify(T1* lhs, T2* rhs, const size_t m) {
   }
 }
 
-inline int hll_sz_for_rate(const int err_percent) {
+inline int hll_size_for_rate(const int err_percent) {
   double err_rate{static_cast<double>(err_percent) / 100.0};
   double k = ceil(2 * log2(1.04 / err_rate));
-  return k > 16 ? 16 : k < 1 ? 1 : k;
+  return std::min(16, std::max(static_cast<int>(k), 1));
 }
 
 extern int g_hll_precision_bits;

--- a/QueryEngine/HyperLogLog.h
+++ b/QueryEngine/HyperLogLog.h
@@ -74,6 +74,12 @@ inline void hll_unify(T1* lhs, T2* rhs, const size_t m) {
   }
 }
 
+inline int hll_sz_for_rate(const int err_percent) {
+  double err_rate{static_cast<double>(err_percent) / 100.0};
+  double k = ceil(2 * log2(1.04 / err_rate));
+  return k > 16 ? 16 : k < 1 ? 1 : k;
+}
+
 extern int g_hll_precision_bits;
 
 #endif  // QUERYENGINE_HYPERLOGLOG_H

--- a/QueryEngine/RelAlgAbstractInterpreter.cpp
+++ b/QueryEngine/RelAlgAbstractInterpreter.cpp
@@ -568,10 +568,10 @@ std::unique_ptr<const RexAgg> parse_aggregate_expr(const rapidjson::Value& expr)
   const auto distinct = json_bool(field(expr, "distinct"));
   const auto agg_ti = parse_type(field(expr, "type"));
   const auto operands = indices_from_json_array(field(expr, "operands"));
-  if (operands.size() > size_t(1)) {
+  if (operands.size() > 1 && (operands.size() != 2 || agg != kAPPROX_COUNT_DISTINCT)) {
     throw QueryNotSupported("Multiple arguments for aggregates aren't supported");
   }
-  return std::unique_ptr<const RexAgg>(new RexAgg(agg, distinct, agg_ti, operands.empty() ? -1 : operands[0]));
+  return std::unique_ptr<const RexAgg>(new RexAgg(agg, distinct, agg_ti, operands));
 }
 
 std::unique_ptr<const RexScalar> parse_scalar_expr(const rapidjson::Value& expr,

--- a/QueryEngine/RelAlgAbstractInterpreter.h
+++ b/QueryEngine/RelAlgAbstractInterpreter.h
@@ -398,29 +398,35 @@ class RexRef : public RexScalar {
 
 class RexAgg : public Rex {
  public:
-  RexAgg(const SQLAgg agg, const bool distinct, const SQLTypeInfo& type, const ssize_t operand)
-      : agg_(agg), distinct_(distinct), type_(type), operand_(operand){};
+  RexAgg(const SQLAgg agg, const bool distinct, const SQLTypeInfo& type, const std::vector<size_t>& operands)
+      : agg_(agg), distinct_(distinct), type_(type), operands_(operands) {}
 
   std::string toString() const override {
-    return "(RexAgg " + std::to_string(agg_) + " " + std::to_string(distinct_) + " " + type_.get_type_name() + " " +
-           type_.get_compression_name() + " " + std::to_string(operand_) + ")";
+    auto result = "(RexAgg " + std::to_string(agg_) + " " + std::to_string(distinct_) + " " + type_.get_type_name() +
+                  " " + type_.get_compression_name();
+    for (auto operand : operands_) {
+      result += " " + std::to_string(operand);
+    }
+    return result + ")";
   }
 
   SQLAgg getKind() const { return agg_; }
 
   bool isDistinct() const { return distinct_; }
 
-  ssize_t getOperand() const { return operand_; }
+  size_t size() const { return operands_.size(); }
+
+  size_t getOperand(size_t idx) const { return operands_[idx]; }
 
   const SQLTypeInfo& getType() const { return type_; }
 
-  std::unique_ptr<RexAgg> deepCopy() const { return boost::make_unique<RexAgg>(agg_, distinct_, type_, operand_); }
+  std::unique_ptr<RexAgg> deepCopy() const { return boost::make_unique<RexAgg>(agg_, distinct_, type_, operands_); }
 
  private:
   const SQLAgg agg_;
   const bool distinct_;
   const SQLTypeInfo type_;
-  const ssize_t operand_;
+  const std::vector<size_t> operands_;
 };
 
 class RelAlgNode {

--- a/QueryEngine/RelAlgExecutor.cpp
+++ b/QueryEngine/RelAlgExecutor.cpp
@@ -1256,9 +1256,9 @@ RelAlgExecutionUnit decide_approx_count_distinct_implementation(
     int64_t approx_bitmap_sz_bits{0};
     const auto error_rate = static_cast<Analyzer::AggExpr*>(target_expr)->get_error_rate();
     if (error_rate) {
-      CHECK(error_rate->get_type_info().is_integer());
-      CHECK_GE(error_rate->get_constval().intval, 1);
-      approx_bitmap_sz_bits = hll_sz_for_rate(error_rate->get_constval().intval);
+      CHECK(error_rate->get_type_info().get_type() == kSMALLINT);
+      CHECK_GE(error_rate->get_constval().smallintval, 1);
+      approx_bitmap_sz_bits = hll_size_for_rate(error_rate->get_constval().smallintval);
     } else {
       approx_bitmap_sz_bits = g_hll_precision_bits;
     }

--- a/QueryEngine/RelAlgTranslator.cpp
+++ b/QueryEngine/RelAlgTranslator.cpp
@@ -178,14 +178,22 @@ std::shared_ptr<Analyzer::Expr> RelAlgTranslator::translateAggregateRex(
     const std::vector<std::shared_ptr<Analyzer::Expr>>& scalar_sources) {
   const auto agg_kind = rex->getKind();
   const bool is_distinct = rex->isDistinct();
-  const auto operand = rex->getOperand();
-  const bool takes_arg{operand >= 0};
+  const bool takes_arg{rex->size() > 0};
+  std::shared_ptr<Analyzer::Expr> arg_expr = nullptr;
+  std::shared_ptr<Analyzer::Constant> err_rate = nullptr;
   if (takes_arg) {
+    const auto operand = rex->getOperand(0);
     CHECK_LT(operand, static_cast<ssize_t>(scalar_sources.size()));
+    arg_expr = scalar_sources[operand];
+    if (agg_kind == kAPPROX_COUNT_DISTINCT && rex->size() == 2) {
+      err_rate = std::dynamic_pointer_cast<Analyzer::Constant>(scalar_sources[rex->getOperand(1)]);
+      if (!err_rate || !err_rate->get_type_info().is_integer() || err_rate->get_constval().bigintval < 1) {
+        throw std::runtime_error("APPROX_COUNT_DISTINCT's second parameter should be integer literal greater than 0");
+      }
+    }
   }
-  const auto arg_expr = takes_arg ? scalar_sources[operand] : nullptr;
   const auto agg_ti = get_agg_type(agg_kind, arg_expr.get());
-  return makeExpr<Analyzer::AggExpr>(agg_ti, agg_kind, arg_expr, is_distinct);
+  return makeExpr<Analyzer::AggExpr>(agg_ti, agg_kind, arg_expr, is_distinct, err_rate);
 }
 
 std::shared_ptr<Analyzer::Expr> RelAlgTranslator::translateLiteral(const RexLiteral* rex_literal) {

--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -858,7 +858,19 @@ TEST(Select, ApproxCountDistinct) {
       "SELECT approx_value, exact_value FROM (SELECT COUNT(distinct x) AS approx_value FROM test), (SELECT "
       "COUNT(distinct x) AS exact_value FROM test);",
       dt);
+    c("SELECT APPROX_COUNT_DISTINCT(x, 1) FROM test;", "SELECT COUNT(distinct x) FROM test;", dt);
+    c("SELECT APPROX_COUNT_DISTINCT(b, 10) FROM test;", "SELECT COUNT(distinct b) FROM test;", dt);
+    c("SELECT APPROX_COUNT_DISTINCT(f, 20) FROM test;", "SELECT COUNT(distinct f) FROM test;", dt);
+    c("SELECT COUNT(*), MIN(x), MAX(x), AVG(y), SUM(z) AS n, APPROX_COUNT_DISTINCT(x, 1) FROM test GROUP BY y ORDER "
+      "BY n;",
+      "SELECT COUNT(*), MIN(x), MAX(x), AVG(y), SUM(z) AS n, COUNT(distinct x) FROM test GROUP BY y ORDER BY n;",
+      dt);
+    c("SELECT COUNT(*), MIN(x), MAX(x), AVG(y), SUM(z) AS n, APPROX_COUNT_DISTINCT(x + 1, 1) FROM test GROUP BY y "
+      "ORDER BY n;",
+      "SELECT COUNT(*), MIN(x), MAX(x), AVG(y), SUM(z) AS n, COUNT(distinct x + 1) FROM test GROUP BY y ORDER BY n;",
+      dt);
     EXPECT_THROW(run_multiple_agg("SELECT APPROX_COUNT_DISTINCT(real_str) FROM test;", dt), std::runtime_error);
+    EXPECT_THROW(run_multiple_agg("SELECT APPROX_COUNT_DISTINCT(x, 0) FROM test;", dt), std::runtime_error);
   }
 }
 

--- a/java/calcite/src/main/java/com/mapd/calcite/parser/MapDSqlOperatorTable.java
+++ b/java/calcite/src/main/java/com/mapd/calcite/parser/MapDSqlOperatorTable.java
@@ -603,7 +603,15 @@ public class MapDSqlOperatorTable extends ChainedSqlOperatorTable {
     static class ApproxCountDistinct extends SqlAggFunction {
 
         ApproxCountDistinct() {
-            super("APPROX_COUNT_DISTINCT", null, SqlKind.OTHER_FUNCTION, null, null, OperandTypes.ANY, SqlFunctionCategory.SYSTEM);
+            super("APPROX_COUNT_DISTINCT",
+                    null,
+                    SqlKind.OTHER_FUNCTION,
+                    null,
+                    null,
+                    OperandTypes.or(
+                            OperandTypes.family(SqlTypeFamily.ANY),
+                            OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)),
+                    SqlFunctionCategory.SYSTEM);
         }
 
         @Override


### PR DESCRIPTION
It closes #29 

Usage: `APPROX_COUNT_DISTINCT(expr, integer_literal)`,
where `integer_literal` is the desired error rate in percents. Should be >= 1.

Internally it calculates a bitmap precision to provide the desired relative
error and uses it instead of `g_hll_precision_bits`.