### PR TITLE
Fixed JDBC ignoring prepared statement parameter at the end of a query

### DIFF
--- a/java/mapdjdbc/src/main/java/com/mapd/jdbc/MapDPreparedStatement.java
+++ b/java/mapdjdbc/src/main/java/com/mapd/jdbc/MapDPreparedStatement.java
@@ -82,7 +82,7 @@ class MapDPreparedStatement implements PreparedStatement {
     this.stmt = new MapDStatement(session, client);
     MAPDLOGGER.debug("Prepared statement is " + currentSQL);
     //TODO in real life this needs to check if the ? isinside quotes before we assume it a parameter
-    brokenSQL = currentSQL.split("\\?");
+    brokenSQL = currentSQL.split("\\?", -1);
     parmCount = brokenSQL.length - 1;
     parmRep = new String[parmCount];
     isParmString = new boolean[parmCount];


### PR DESCRIPTION
Closes #45 

To reproduce: "SELECT * FROM t WHERE id = ?"
Negative "limit" argument in String.split() prevents it from ignoring empty splits