### PR TITLE
Fix reverse_logical_distribution corner cases

### DIFF
--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -3237,6 +3237,7 @@ TEST(Select, Joins_ImplicitJoins) {
     c("SELECT COUNT(*) FROM test, test_inner WHERE (test.x = test_inner.x AND test.y = 42 AND test_inner.str = 'foo') "
       "OR (test.x = test_inner.x AND test.y = 43 AND test_inner.str = 'foo');",
       dt);
+    c("SELECT COUNT(*) FROM test, test_inner WHERE test.x = test_inner.x OR test.x = test_inner.x;", dt);
     ASSERT_EQ(
         int64_t(3),
         v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test, join_test WHERE test.rowid = join_test.rowid;", dt)));


### PR DESCRIPTION
Handle the case where nothing is left after extracting the common expression.