### PR TITLE
Switch to token-based completion hints

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(StorageTest StorageTest.cpp PopulateTableRandom.cpp ScanTable.cpp
 add_executable(StoragePerfTest StoragePerfTest.cpp PopulateTableRandom.cpp ScanTable.cpp)
 add_executable(ImportTest ImportTest.cpp QueryRunner.cpp)
 add_executable(TopKTest TopKTest.cpp QueryRunner.cpp)
+add_executable(TokenCompletionHintsTest TokenCompletionHintsTest.cpp)
 
 target_link_libraries(PlanTest gtest ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${Glog_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${LLVM_LINKER_FLAGS} ${CURSES_LIBRARIES})
 target_link_libraries(ProfileTest gtest ${MAPD_LIBRARIES} ${Boost_LIBRARIES} ${Glog_LIBRARIES} ${CMAKE_DL_LIBS} ${CUDA_LIBRARIES} ${PROF_LIBRARIES} ${LLVM_LINKER_FLAGS} ${CURSES_LIBRARIES})
@@ -55,6 +56,7 @@ target_link_libraries(RunQueryLoop ${EXECUTE_TEST_LIBS})
 target_link_libraries(StringDictionaryTest StringDictionary gtest ${Boost_LIBRARIES})
 target_link_libraries(ImportTest gtest ${EXECUTE_TEST_LIBS})
 target_link_libraries(TopKTest ${EXECUTE_TEST_LIBS})
+target_link_libraries(TokenCompletionHintsTest token_completion_hints gtest mapd_thrift ${Boost_LIBRARIES})
 
 set(TEST_ARGS "--gtest_output=xml:../")
 add_test(PlanTest PlanTest ${TEST_ARGS})
@@ -68,18 +70,19 @@ add_test(StringDictionaryTest StringDictionaryTest ${TEST_ARGS})
 add_test(StorageTest StorageTest ${TEST_ARGS})
 add_test(StoragePerfTest StoragePerfTest ${TEST_ARGS})
 add_test(TopKTest TopKTest ${TEST_ARGS})
+add_test(TokenCompletionHintsTest TokenCompletionHintsTest ${TEST_ARGS})
 
 add_custom_target(sanity_tests
     COMMAND mkdir -p ${TEST_BASE_PATH}
     COMMAND initdb -f ${TEST_BASE_PATH}
-    COMMAND ${CMAKE_CTEST_COMMAND} --verbose --tests-regex "\"(PlanTest|ExecuteTest|ResultSetTest|ResultSetBaselineRadixSortTest|StorageTest|ImportTest|TopKTest)\""
-    DEPENDS PlanTest ExecuteTest ResultSetTest ResultSetBaselineRadixSortTest StorageTest ImportTest TopKTest)
+    COMMAND ${CMAKE_CTEST_COMMAND} --verbose --tests-regex "\"(PlanTest|ExecuteTest|ResultSetTest|ResultSetBaselineRadixSortTest|StorageTest|ImportTest|TopKTest|TokenCompletionHintsTest)\""
+    DEPENDS PlanTest ExecuteTest ResultSetTest ResultSetBaselineRadixSortTest StorageTest ImportTest TopKTest TokenCompletionHintsTest)
 
 add_custom_target(all_tests
     COMMAND mkdir -p ${TEST_BASE_PATH}
     COMMAND initdb -f ${TEST_BASE_PATH}
     COMMAND ${CMAKE_CTEST_COMMAND} --verbose
-    DEPENDS PlanTest ProfileTest UtilTest ExecuteTest ResultSetTest ResultSetBaselineRadixSortTest RunQueryLoop StringDictionaryTest StorageTest StoragePerfTest ImportTest TopKTest)
+    DEPENDS PlanTest ProfileTest UtilTest ExecuteTest ResultSetTest ResultSetBaselineRadixSortTest RunQueryLoop StringDictionaryTest StorageTest StoragePerfTest ImportTest TopKTest TokenCompletionHintsTest)
 
 add_custom_target(storage_perf_tests
     COMMAND mkdir -p ${TEST_BASE_PATH}

--- a/Tests/TokenCompletionHintsTest.cpp
+++ b/Tests/TokenCompletionHintsTest.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../ThriftHandler/TokenCompletionHints.h"
+
+#include <gtest/gtest.h>
+
+TEST(FindLastWord, SimpleId) {
+  std::string partial_query{"SELECT test"};
+  ASSERT_EQ("test", find_last_word_from_cursor(partial_query, partial_query.size()));
+}
+
+TEST(FindLastWord, QualifiedId) {
+  std::string partial_query{"SELECT test.x"};
+  ASSERT_EQ("test.x", find_last_word_from_cursor(partial_query, partial_query.size()));
+}
+
+TEST(FindLastWord, CursorPastEnd) {
+  std::string partial_query{"SELECT test"};
+  ASSERT_EQ("", find_last_word_from_cursor(partial_query, partial_query.size() + 1));
+}
+
+TEST(FindLastWord, CursorInside) {
+  std::string partial_query{"SELECT str FROM te LIMIT 10"};
+  ASSERT_EQ("te", find_last_word_from_cursor(partial_query, 18));
+}
+
+TEST(FindLastWord, EmptyString) {
+  ASSERT_EQ("", find_last_word_from_cursor("", 0));
+  ASSERT_EQ("", find_last_word_from_cursor("", 1));
+  ASSERT_EQ("", find_last_word_from_cursor("", -1));
+}
+
+namespace {
+
+void assert_set_equals(const std::vector<std::string>& expected, const std::vector<std::string>& actual) {
+  auto actual_sorted = actual;
+  std::sort(actual_sorted.begin(), actual_sorted.end());
+  auto expected_sorted = expected;
+  std::sort(expected_sorted.begin(), expected_sorted.end());
+  ASSERT_EQ(expected_sorted, actual_sorted);
+}
+
+}  // namespace
+
+TEST(Completion, QualifiedColumnName) {
+  std::unordered_map<std::string, std::unordered_set<std::string>> column_names_by_table;
+  column_names_by_table["test"] = {"x", "ss", "str"};
+  column_names_by_table["test_inner"] = {"x"};
+  {
+    std::vector<TCompletionHint> completion_hints;
+    std::string last_word{"test.x"};
+    ASSERT_TRUE(get_qualified_column_hints(completion_hints, last_word, column_names_by_table));
+    ASSERT_EQ(size_t(1), completion_hints.size());
+    ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
+    ASSERT_EQ(last_word, completion_hints.front().replaced);
+    assert_set_equals({"x"}, completion_hints.front().hints);
+  }
+  {
+    std::vector<TCompletionHint> completion_hints;
+    std::string last_word{"test.s"};
+    ASSERT_TRUE(get_qualified_column_hints(completion_hints, last_word, column_names_by_table));
+    ASSERT_EQ(size_t(1), completion_hints.size());
+    ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
+    ASSERT_EQ(last_word, completion_hints.front().replaced);
+    assert_set_equals({"ss", "str"}, completion_hints.front().hints);
+  }
+  {
+    std::vector<TCompletionHint> completion_hints;
+    std::string last_word{"test."};
+    ASSERT_TRUE(get_qualified_column_hints(completion_hints, last_word, column_names_by_table));
+    ASSERT_EQ(size_t(1), completion_hints.size());
+    ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
+    ASSERT_EQ(last_word, completion_hints.front().replaced);
+    assert_set_equals({"x", "ss", "str"}, completion_hints.front().hints);
+  }
+  {
+    std::vector<TCompletionHint> completion_hints;
+    ASSERT_TRUE(get_qualified_column_hints(completion_hints, "test.y", column_names_by_table));
+    ASSERT_TRUE(completion_hints.empty());
+  }
+}
+
+TEST(Completion, ColumnName) {
+  std::unordered_map<std::string, std::unordered_set<std::string>> column_names_by_table;
+  column_names_by_table["test"] = {"x", "ss", "str"};
+  column_names_by_table["test_inner"] = {"x"};
+  {
+    std::vector<TCompletionHint> completion_hints;
+    std::string last_word{"s"};
+    get_column_hints(completion_hints, last_word, column_names_by_table);
+    ASSERT_EQ(size_t(1), completion_hints.size());
+    ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
+    ASSERT_EQ(last_word, completion_hints.front().replaced);
+    assert_set_equals({"ss", "str"}, completion_hints.front().hints);
+  }
+  {
+    std::vector<TCompletionHint> completion_hints;
+    std::string last_word{"x"};
+    get_column_hints(completion_hints, last_word, column_names_by_table);
+    ASSERT_EQ(size_t(1), completion_hints.size());
+    ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
+    ASSERT_EQ(last_word, completion_hints.front().replaced);
+    assert_set_equals({"x"}, completion_hints.front().hints);
+  }
+  {
+    std::vector<TCompletionHint> completion_hints;
+    get_column_hints(completion_hints, "y", column_names_by_table);
+    ASSERT_TRUE(completion_hints.empty());
+  }
+}
+
+TEST(Completion, TableName) {
+  std::unordered_map<std::string, std::unordered_set<std::string>> column_names_by_table;
+  column_names_by_table["test"] = {"x", "ss", "str"};
+  column_names_by_table["test_inner"] = {"x"};
+  {
+    std::vector<TCompletionHint> completion_hints;
+    std::string last_word{"t"};
+    get_table_hints(completion_hints, last_word, column_names_by_table);
+    ASSERT_EQ(size_t(1), completion_hints.size());
+    ASSERT_TRUE(TCompletionHintType::TABLE == completion_hints.front().type);
+    ASSERT_EQ(last_word, completion_hints.front().replaced);
+    assert_set_equals({"test", "test_inner"}, completion_hints.front().hints);
+  }
+  {
+    std::vector<TCompletionHint> completion_hints;
+    get_table_hints(completion_hints, "tt", column_names_by_table);
+    ASSERT_TRUE(completion_hints.empty());
+  }
+}
+
+TEST(Completion, FilterKeywords) {
+  std::vector<TCompletionHint> original_hints;
+  std::vector<TCompletionHint> expected_filtered_hints;
+  {
+    TCompletionHint hint;
+    hint.type = TCompletionHintType::COLUMN;
+    hint.hints.emplace_back("foo");
+    original_hints.push_back(hint);
+  }
+  {
+    TCompletionHint hint;
+    hint.type = TCompletionHintType::KEYWORD;
+    hint.hints.emplace_back("SUBSTR");
+    original_hints.push_back(hint);
+  }
+  {
+    TCompletionHint hint;
+    hint.type = TCompletionHintType::KEYWORD;
+    hint.hints.emplace_back("GROUP");
+    original_hints.push_back(hint);
+    expected_filtered_hints.push_back(hint);
+  }
+  const auto filtered_hints = just_whitelisted_keyword_hints(original_hints);
+  ASSERT_EQ(expected_filtered_hints, filtered_hints);
+}
+
+TEST(Completion, Keywords) {
+  {
+    const std::string keyword_prefix{"sel"};
+    const auto completion_hints = get_keyword_hints(keyword_prefix);
+    ASSERT_EQ(keyword_prefix, completion_hints.front().replaced);
+    assert_set_equals({"SELECT"}, completion_hints.front().hints);
+  }
+  {
+    const std::string keyword_prefix{"fr"};
+    const auto completion_hints = get_keyword_hints(keyword_prefix);
+    ASSERT_EQ(keyword_prefix, completion_hints.front().replaced);
+    assert_set_equals({"FROM"}, completion_hints.front().hints);
+  }
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/ThriftHandler/CMakeLists.txt
+++ b/ThriftHandler/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(THRIFT_HANDLER_SOURCES MapDHandler.cpp)
+set(THRIFT_HANDLER_SOURCES MapDHandler.cpp TokenCompletionHints.cpp)
 set(THRIFT_HANDLER_LIBS mapd_thrift Shared ${Glog_LIBRARIES} ${CMAKE_DL_LIBS})
 
 if("${MAPD_EDITION_LOWER}" STREQUAL "ee")
@@ -12,5 +12,6 @@ else()
   include_directories("${CMAKE_CURRENT_SOURCE_DIR}/os")
 endif()
 
+add_library(token_completion_hints TokenCompletionHints.cpp)
 add_library(thrift_handler ${THRIFT_HANDLER_SOURCES})
-target_link_libraries(thrift_handler ${THRIFT_HANDLER_LIBS})
+target_link_libraries(thrift_handler token_completion_hints ${THRIFT_HANDLER_LIBS})

--- a/ThriftHandler/MapDHandler.h
+++ b/ThriftHandler/MapDHandler.h
@@ -437,6 +437,9 @@ class MapDHandler : public MapDIf {
                                           const Catalog_Namespace::SessionInfo& session_info,
                                           const std::string& action /* render or validate */);
 
+  std::unordered_map<std::string, std::unordered_set<std::string>> fill_column_names_by_table(
+      const TSessionId& session);
+
   bool super_user_rights_;  // default is "false"; setting to "true" ignores passwd checks in "connect(..)" method
   const bool access_priv_check_;
 

--- a/ThriftHandler/TokenCompletionHints.cpp
+++ b/ThriftHandler/TokenCompletionHints.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TokenCompletionHints.h"
+#include "Shared/StringTransform.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+namespace {
+
+bool is_qualified_identifier_part(const char ch) {
+  return isalnum(ch) || ch == '_' || ch == '.';
+}
+
+}  // namespace
+
+// Straightforward port from SqlAdvisor.getCompletionHints.
+std::string find_last_word_from_cursor(const std::string& sql, const ssize_t cursor) {
+  if (cursor > static_cast<ssize_t>(sql.size())) {
+    return "";
+  }
+  auto word_start = cursor;
+  bool quoted = false;
+  while (word_start > 0 && is_qualified_identifier_part(sql[word_start - 1])) {
+    --word_start;
+  }
+  if ((word_start > 0) && (sql[word_start - 1] == '"')) {
+    quoted = true;
+    --word_start;
+  }
+
+  if (word_start < 0) {
+    return "";
+  }
+
+  // Search forwards to the end of the word we should remove. Eat up
+  // trailing double-quote, if any
+  auto word_end = cursor;
+  while (word_end < static_cast<ssize_t>(sql.size()) && is_qualified_identifier_part(sql[word_end - 1])) {
+    ++word_end;
+  }
+  if (quoted && (word_end < static_cast<ssize_t>(sql.size())) && (sql[word_end] == '"')) {
+    ++word_end;
+  }
+  std::string last_word(sql.begin() + word_start + (quoted ? 1 : 0), sql.begin() + cursor);
+  return last_word;
+}
+
+std::vector<TCompletionHint> just_whitelisted_keyword_hints(const std::vector<TCompletionHint>& hints) {
+  static const std::unordered_set<std::string> whitelisted_keywords{
+      "WHERE", "GROUP", "BY", "COUNT", "AVG", "MAX", "MIN", "SUM", "STDDEV_POP", "STDDEV_SAMP"};
+  std::vector<TCompletionHint> filtered;
+  for (const auto& original_hint : hints) {
+    if (original_hint.type != TCompletionHintType::KEYWORD) {
+      continue;
+    }
+    auto filtered_hint = original_hint;
+    filtered_hint.hints.clear();
+    for (const auto hint_token : original_hint.hints) {
+      if (whitelisted_keywords.find(to_upper(hint_token)) != whitelisted_keywords.end()) {
+        filtered_hint.hints.push_back(hint_token);
+      }
+    }
+    if (!filtered_hint.hints.empty()) {
+      filtered.push_back(filtered_hint);
+    }
+  }
+  return filtered;
+}
+
+bool get_qualified_column_hints(
+    std::vector<TCompletionHint>& hints,
+    const std::string& last_word,
+    const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table) {
+  std::vector<std::string> last_word_tokens;
+  boost::split(last_word_tokens, last_word, boost::is_any_of("."));
+  if (last_word_tokens.size() < 2) {
+    return false;
+  }
+  const auto table_name = last_word_tokens[last_word_tokens.size() - 2];
+  const auto col_names_it = column_names_by_table.find(table_name);
+  if (col_names_it == column_names_by_table.end()) {
+    return false;
+  }
+  TCompletionHint column_hint;
+  column_hint.type = TCompletionHintType::COLUMN;
+  column_hint.replaced = last_word;
+  for (const auto& col_name : col_names_it->second) {
+    if (boost::istarts_with(col_name, last_word_tokens.back())) {
+      column_hint.hints.push_back(col_name);
+    }
+  }
+  if (!column_hint.hints.empty()) {
+    hints.push_back(column_hint);
+  }
+  return true;
+}
+
+void get_column_hints(std::vector<TCompletionHint>& hints,
+                      const std::string& last_word,
+                      const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table) {
+  TCompletionHint column_hint;
+  column_hint.type = TCompletionHintType::COLUMN;
+  column_hint.replaced = last_word;
+  std::unordered_set<std::string> column_hints_deduped;
+  for (const auto& kv : column_names_by_table) {
+    for (const auto& col_name : kv.second) {
+      if (boost::istarts_with(col_name, last_word)) {
+        column_hints_deduped.insert(col_name);
+      }
+    }
+  }
+  column_hint.hints.insert(column_hint.hints.end(), column_hints_deduped.begin(), column_hints_deduped.end());
+  if (!column_hint.hints.empty()) {
+    hints.push_back(column_hint);
+  }
+}
+
+void get_table_hints(std::vector<TCompletionHint>& hints,
+                     const std::string& last_word,
+                     const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table) {
+  TCompletionHint table_hint;
+  table_hint.type = TCompletionHintType::TABLE;
+  table_hint.replaced = last_word;
+  for (const auto& kv : column_names_by_table) {
+    if (boost::istarts_with(kv.first, last_word)) {
+      table_hint.hints.emplace_back(kv.first);
+    }
+  }
+  if (!table_hint.hints.empty()) {
+    hints.push_back(table_hint);
+  }
+}
+
+std::vector<TCompletionHint> get_keyword_hints(const std::string& keyword_prefix) {
+  std::vector<TCompletionHint> keywords;
+  auto make_keyword_hint = [&keyword_prefix](const std::string& keyword) {
+    TCompletionHint keyword_hint;
+    keyword_hint.type = TCompletionHintType::KEYWORD;
+    keyword_hint.replaced = keyword_prefix;
+    keyword_hint.hints.emplace_back(keyword);
+    return keyword_hint;
+  };
+  const std::string kSelectKeyword{"SELECT"};
+  const std::string kFromKeyword{"FROM"};
+  if (boost::istarts_with(kSelectKeyword, keyword_prefix)) {
+    keywords.push_back(make_keyword_hint(kSelectKeyword));
+  } else if (boost::istarts_with(kFromKeyword, keyword_prefix)) {
+    keywords.push_back(make_keyword_hint(kFromKeyword));
+  }
+  return keywords;
+}

--- a/ThriftHandler/TokenCompletionHints.h
+++ b/ThriftHandler/TokenCompletionHints.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 MapD Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef THRIFTHANDLER_TOKENCOMPLETIONHINTS_H
+#define THRIFTHANDLER_TOKENCOMPLETIONHINTS_H
+
+#include "gen-cpp/completion_hints_types.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+// Find last "word" (can contain: alphanumeric, underscore, dot) from position
+// `cursor` inside or at the end of `sql`.
+std::string find_last_word_from_cursor(const std::string& sql, const ssize_t cursor);
+
+// Only allows a few whitelisted keywords, filters out everything else.
+std::vector<TCompletionHint> just_whitelisted_keyword_hints(const std::vector<TCompletionHint>& hints);
+
+// Given last_word = "table.prefix", returns column hints for all columns in "table" which start with "prefix" from
+// `column_names_by_table["table"]`. Returns true iff `last_word` looks like a qualified name (contains a dot).
+bool get_qualified_column_hints(
+    std::vector<TCompletionHint>& hints,
+    const std::string& last_word,
+    const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table);
+
+// Returns column hints for the flattened list of all values in `column_names_by_table` which start with `last_word`.
+void get_column_hints(std::vector<TCompletionHint>& hints,
+                      const std::string& last_word,
+                      const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table);
+
+// Returns table hints for all keys which start with `last_word` from `column_names_by_table`.
+void get_table_hints(std::vector<TCompletionHint>& hints,
+                     const std::string& last_word,
+                     const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table);
+
+// Returns keyword hints which start with "keyword_prefix".
+std::vector<TCompletionHint> get_keyword_hints(const std::string& keyword_prefix);
+
+#endif  // THRIFTHANDLER_TOKENCOMPLETIONHINTS_H


### PR DESCRIPTION
Calcite doesn't honor our permissions and the context-sensitive identifier
completion is brittle. Only use it for keywords, filtered by a narrow
whitelist.