### PR TITLE
Implementation of feature requested in Issue#138, re: mapdql commands regex

### DIFF
--- a/SQLFrontend/CMakeLists.txt
+++ b/SQLFrontend/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost COMPONENTS program_options filesystem system REQUIRED QUIET)
+find_package(Boost COMPONENTS program_options filesystem regex system REQUIRED QUIET)
 add_executable(mapdql mapdql.cpp)
 
 target_link_libraries(mapdql mapd_thrift Shared linenoise ${Boost_LIBRARIES} ${Glog_LIBRARIES} ${CMAKE_DL_LIBS})


### PR DESCRIPTION
- Used boost::regex as requested
- Uses search instead of match mechanics, so substring searches can be applied
- Tried to clean up some repetitive constructs and provided some new functions with lambda expressions on return from thrift queries with retry
- No regex provided reverts to unfiltered output, like before
- Commit formatted with clang-format, as required

Some examples:

**Unfiltered Table Output**
> mapdql> \t
> flights_2008_7M
> test
> test_x
> test_inner_x
> bar
> test_inner
> 

**End of line match**
> mapdql> \t _x$
> test_x
> test_inner_x

**Inner match**

> mapdql> \t _inner_
> test_inner_x
> 

And it works on \u and \v as well:

**Unfiltered User Output**

> mapdql> \u
> mapd
> homer
> marge
> bart
> lisa
> lisaSimpson
> sideshowbob
> 

**Start of line match**
> mapdql> \u ^lisa
> lisa
> lisaSimpson
> mapdql> 
> 

**Unfiltered View Output**

> mapdql> \v
> test_view
> cletus
> marge
> marge978
> marge1025
> mapdql> 
> 

**Specific digit width end of line match**

> mapdql> \v \d{4}$
> marge1025
> 