### PR TITLE
Fix issues with operand nullability for time comparisons

### DIFF
--- a/Analyzer/Analyzer.cpp
+++ b/Analyzer/Analyzer.cpp
@@ -190,6 +190,7 @@ SQLTypeInfo BinOper::analyze_type_info(SQLOps op,
                 *new_left_type =
                     SQLTypeInfo(left_type.get_type(), left_type.get_dimension(), 0, left_type.get_notnull());
                 *new_right_type = *new_left_type;
+                new_right_type->set_notnull(right_type.get_notnull());
                 break;
               case kTIMESTAMP:
                 *new_left_type = SQLTypeInfo(kTIMESTAMP,
@@ -229,13 +230,15 @@ SQLTypeInfo BinOper::analyze_type_info(SQLOps op,
             switch (right_type.get_type()) {
               case kTIMESTAMP:
                 *new_left_type =
-                    SQLTypeInfo(right_type.get_type(), right_type.get_dimension(), 0, right_type.get_notnull());
+                    SQLTypeInfo(right_type.get_type(), right_type.get_dimension(), 0, left_type.get_notnull());
                 *new_right_type = *new_left_type;
+                new_right_type->set_notnull(right_type.get_notnull());
                 break;
               case kDATE:
                 *new_left_type =
                     SQLTypeInfo(left_type.get_type(), left_type.get_dimension(), 0, left_type.get_notnull());
                 *new_right_type = *new_left_type;
+                new_right_type->set_notnull(right_type.get_notnull());
                 break;
               case kTIME:
                 throw std::runtime_error("Cannont compare between DATE and TIME.");

--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -1474,13 +1474,13 @@ TEST(Select, Time) {
   for (auto dt : {ExecutorDeviceType::CPU, ExecutorDeviceType::GPU}) {
     SKIP_NO_GPU();
     // check DATE Formats
-    ASSERT_EQ(2 * g_num_rows,
+    ASSERT_EQ(g_num_rows + g_num_rows / 2,
               v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test WHERE CAST('1999-09-10' AS DATE) > o;", dt)));
-    ASSERT_EQ(2 * g_num_rows,
+    ASSERT_EQ(g_num_rows + g_num_rows / 2,
               v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test WHERE CAST('10/09/1999' AS DATE) > o;", dt)));
-    ASSERT_EQ(2 * g_num_rows,
+    ASSERT_EQ(g_num_rows + g_num_rows / 2,
               v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test WHERE CAST('10-Sep-99' AS DATE) > o;", dt)));
-    ASSERT_EQ(2 * g_num_rows,
+    ASSERT_EQ(g_num_rows + g_num_rows / 2,
               v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test WHERE CAST('31/Oct/2013' AS DATE) > o;", dt)));
     // check TIME FORMATS
     ASSERT_EQ(2 * g_num_rows,
@@ -1488,7 +1488,7 @@ TEST(Select, Time) {
     ASSERT_EQ(2 * g_num_rows,
               v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test WHERE CAST('151315' AS TIME) > n;", dt)));
 
-    ASSERT_EQ(2 * g_num_rows,
+    ASSERT_EQ(g_num_rows + g_num_rows / 2,
               v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test WHERE CAST('1999-09-10' AS DATE) > o;", dt)));
     ASSERT_EQ(0, v<int64_t>(run_simple_agg("SELECT COUNT(*) FROM test WHERE CAST('1999-09-10' AS DATE) <= o;", dt)));
     ASSERT_EQ(2 * g_num_rows,


### PR DESCRIPTION
BinOper::analyze_type_info must preserve nullability for both sides.