### PR TITLE
Decompress dictionary-encoded sides when encoding is different

### DIFF
--- a/Parser/ParserNode.cpp
+++ b/Parser/ParserNode.cpp
@@ -201,7 +201,8 @@ std::shared_ptr<Analyzer::Expr> OperExpr::normalize(const SQLOps optype,
   }
   auto check_compression = (g_fast_strcmp) ? IS_COMPARISON(optype) : IS_EQUIVALENCE(optype) || optype == kNE;
   if (check_compression) {
-    if (new_left_type.get_compression() == kENCODING_DICT && new_right_type.get_compression() == kENCODING_DICT) {
+    if (new_left_type.get_compression() == kENCODING_DICT && new_right_type.get_compression() == kENCODING_DICT &&
+        new_left_type.get_comp_param() == new_right_type.get_comp_param()) {
       // do nothing
     } else if (new_left_type.get_compression() == kENCODING_DICT &&
                new_right_type.get_compression() == kENCODING_NONE) {

--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -1183,6 +1183,8 @@ TEST(Select, Strings) {
     c("SELECT COUNT(*) FROM test WHERE str = 'foo' OR str = 'bar';", dt);
     c("SELECT COUNT(*) FROM test WHERE str = real_str;", dt);
     c("SELECT COUNT(*) FROM test WHERE str <> str;", dt);
+    c("SELECT COUNT(*) FROM test WHERE ss <> str;", dt);
+    c("SELECT COUNT(*) FROM test WHERE ss = str;", dt);
     c("SELECT COUNT(*) FROM test WHERE LENGTH(str) = 3;", dt);
     c("SELECT fixed_str, COUNT(*) FROM test GROUP BY fixed_str HAVING COUNT(*) > 5 ORDER BY fixed_str;", dt);
     c("SELECT fixed_str, COUNT(*) FROM test WHERE fixed_str = 'bar' GROUP BY fixed_str HAVING COUNT(*) > 4 ORDER BY "


### PR DESCRIPTION
Commit f2a2b5b41b7b347ed9e85be7509b2472632a9598 changed the logic to
account for dictionaries with the same encoding, but it didn't check
that the dictionaries are actually shared (same compression parameter).