### PR TITLE
Context-sensitive auto completion

### DIFF
--- a/Calcite/Calcite.cpp
+++ b/Calcite/Calcite.cpp
@@ -221,6 +221,7 @@ string Calcite::process(const Catalog_Namespace::SessionInfo& session_info,
 }
 
 std::vector<TCompletionHint> Calcite::getCompletionHints(const Catalog_Namespace::SessionInfo& session_info,
+                                                         const std::vector<std::string>& visible_tables,
                                                          const std::string sql_string,
                                                          const int cursor) {
   std::vector<TCompletionHint> hints;
@@ -229,7 +230,7 @@ std::vector<TCompletionHint> Calcite::getCompletionHints(const Catalog_Namespace
   const auto session = session_info.get_session_id();
   const auto catalog = cat.get_currentDB().dbName;
   auto client = get_client(remote_calcite_port_);
-  client.first->getCompletionHints(hints, user, session, catalog, sql_string, cursor);
+  client.first->getCompletionHints(hints, user, session, catalog, visible_tables, sql_string, cursor);
   return hints;
 }
 

--- a/Calcite/Calcite.h
+++ b/Calcite/Calcite.h
@@ -43,6 +43,7 @@ class Calcite {
                       const bool legacy_syntax,
                       const bool is_explain);
   std::vector<TCompletionHint> getCompletionHints(const Catalog_Namespace::SessionInfo& session_info,
+                                                  const std::vector<std::string>& visible_tables,
                                                   const std::string sql_string,
                                                   const int cursor);
   std::string getExtensionFunctionWhitelist();

--- a/Tests/TokenCompletionHintsTest.cpp
+++ b/Tests/TokenCompletionHintsTest.cpp
@@ -67,7 +67,7 @@ TEST(Completion, QualifiedColumnName) {
     ASSERT_EQ(size_t(1), completion_hints.size());
     ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
     ASSERT_EQ(last_word, completion_hints.front().replaced);
-    assert_set_equals({"x"}, completion_hints.front().hints);
+    assert_set_equals({"test.x"}, completion_hints.front().hints);
   }
   {
     std::vector<TCompletionHint> completion_hints;
@@ -76,7 +76,7 @@ TEST(Completion, QualifiedColumnName) {
     ASSERT_EQ(size_t(1), completion_hints.size());
     ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
     ASSERT_EQ(last_word, completion_hints.front().replaced);
-    assert_set_equals({"ss", "str"}, completion_hints.front().hints);
+    assert_set_equals({"test.ss", "test.str"}, completion_hints.front().hints);
   }
   {
     std::vector<TCompletionHint> completion_hints;
@@ -85,7 +85,7 @@ TEST(Completion, QualifiedColumnName) {
     ASSERT_EQ(size_t(1), completion_hints.size());
     ASSERT_TRUE(TCompletionHintType::COLUMN == completion_hints.front().type);
     ASSERT_EQ(last_word, completion_hints.front().replaced);
-    assert_set_equals({"x", "ss", "str"}, completion_hints.front().hints);
+    assert_set_equals({"test.x", "test.ss", "test.str"}, completion_hints.front().hints);
   }
   {
     std::vector<TCompletionHint> completion_hints;
@@ -123,26 +123,6 @@ TEST(Completion, ColumnName) {
   }
 }
 
-TEST(Completion, TableName) {
-  std::unordered_map<std::string, std::unordered_set<std::string>> column_names_by_table;
-  column_names_by_table["test"] = {"x", "ss", "str"};
-  column_names_by_table["test_inner"] = {"x"};
-  {
-    std::vector<TCompletionHint> completion_hints;
-    std::string last_word{"t"};
-    get_table_hints(completion_hints, last_word, column_names_by_table);
-    ASSERT_EQ(size_t(1), completion_hints.size());
-    ASSERT_TRUE(TCompletionHintType::TABLE == completion_hints.front().type);
-    ASSERT_EQ(last_word, completion_hints.front().replaced);
-    assert_set_equals({"test", "test_inner"}, completion_hints.front().hints);
-  }
-  {
-    std::vector<TCompletionHint> completion_hints;
-    get_table_hints(completion_hints, "tt", column_names_by_table);
-    ASSERT_TRUE(completion_hints.empty());
-  }
-}
-
 TEST(Completion, FilterKeywords) {
   std::vector<TCompletionHint> original_hints;
   std::vector<TCompletionHint> expected_filtered_hints;
@@ -151,6 +131,7 @@ TEST(Completion, FilterKeywords) {
     hint.type = TCompletionHintType::COLUMN;
     hint.hints.emplace_back("foo");
     original_hints.push_back(hint);
+    expected_filtered_hints.push_back(hint);
   }
   {
     TCompletionHint hint;
@@ -167,21 +148,6 @@ TEST(Completion, FilterKeywords) {
   }
   const auto filtered_hints = just_whitelisted_keyword_hints(original_hints);
   ASSERT_EQ(expected_filtered_hints, filtered_hints);
-}
-
-TEST(Completion, Keywords) {
-  {
-    const std::string keyword_prefix{"sel"};
-    const auto completion_hints = get_keyword_hints(keyword_prefix);
-    ASSERT_EQ(keyword_prefix, completion_hints.front().replaced);
-    assert_set_equals({"SELECT"}, completion_hints.front().hints);
-  }
-  {
-    const std::string keyword_prefix{"fr"};
-    const auto completion_hints = get_keyword_hints(keyword_prefix);
-    ASSERT_EQ(keyword_prefix, completion_hints.front().replaced);
-    assert_set_equals({"FROM"}, completion_hints.front().hints);
-  }
 }
 
 int main(int argc, char** argv) {

--- a/ThriftHandler/MapDHandler.h
+++ b/ThriftHandler/MapDHandler.h
@@ -432,12 +432,22 @@ class MapDHandler : public MapDIf {
 
   TRowDescriptor convert_target_metainfo(const std::vector<TargetMetaInfo>& targets) const;
 
+  void get_completion_hints_unsorted(std::vector<TCompletionHint>& hints,
+                                     const TSessionId& session,
+                                     const std::string& sql,
+                                     const int cursor);
+  void get_token_based_completions(std::vector<TCompletionHint>& hints,
+                                   const TSessionId& session,
+                                   const std::vector<std::string>& visible_tables,
+                                   const std::string& sql,
+                                   const int cursor);
   Planner::RootPlan* parse_to_plan(const std::string& query_str, const Catalog_Namespace::SessionInfo& session_info);
   Planner::RootPlan* parse_to_plan_legacy(const std::string& query_str,
                                           const Catalog_Namespace::SessionInfo& session_info,
                                           const std::string& action /* render or validate */);
 
   std::unordered_map<std::string, std::unordered_set<std::string>> fill_column_names_by_table(
+      const std::vector<std::string>& table_names,
       const TSessionId& session);
 
   bool super_user_rights_;  // default is "false"; setting to "true" ignores passwd checks in "connect(..)" method

--- a/ThriftHandler/MapDHandler.h
+++ b/ThriftHandler/MapDHandler.h
@@ -433,6 +433,7 @@ class MapDHandler : public MapDIf {
   TRowDescriptor convert_target_metainfo(const std::vector<TargetMetaInfo>& targets) const;
 
   void get_completion_hints_unsorted(std::vector<TCompletionHint>& hints,
+                                     std::vector<std::string>& visible_tables,
                                      const TSessionId& session,
                                      const std::string& sql,
                                      const int cursor);
@@ -447,6 +448,14 @@ class MapDHandler : public MapDIf {
                                           const std::string& action /* render or validate */);
 
   std::unordered_map<std::string, std::unordered_set<std::string>> fill_column_names_by_table(
+      const std::vector<std::string>& table_names,
+      const TSessionId& session);
+
+  // For the provided upper case column names `uc_column_names`, return the tables
+  // from `table_names` which contain at least one of them. Used to rank the TABLE
+  // auto-completion hints by the columns specified in the projection.
+  std::unordered_set<std::string> get_uc_compatible_table_names_by_column(
+      const std::unordered_set<std::string>& uc_column_names,
       const std::vector<std::string>& table_names,
       const TSessionId& session);
 

--- a/ThriftHandler/TokenCompletionHints.cpp
+++ b/ThriftHandler/TokenCompletionHints.cpp
@@ -62,8 +62,9 @@ std::string find_last_word_from_cursor(const std::string& sql, const ssize_t cur
 
 std::vector<TCompletionHint> just_whitelisted_keyword_hints(const std::vector<TCompletionHint>& hints) {
   static const std::unordered_set<std::string> whitelisted_keywords{
-      "WHERE", "GROUP", "BY",   "COUNT", "AVG",    "MAX",   "MIN", "SUM", "STDDEV_POP", "STDDEV_SAMP", "AS",   "HAVING",
-      "INNER", "JOIN",  "LEFT", "LIMIT", "OFFSET", "ORDER", "IN",  "IS",  "NULL",       "NOT",         "LIKE", "*"};
+      "WHERE",  "GROUP", "BY",   "COUNT", "AVG",   "MAX",    "MIN",   "SUM", "STDDEV_POP", "STDDEV_SAMP", "AS",
+      "HAVING", "INNER", "JOIN", "LEFT",  "LIMIT", "OFFSET", "ORDER", "ASC", "DESC",       "DISTINCT",    "IN",
+      "IS",     "NULL",  "NOT",  "AND",   "OR",    "LIKE",   "*",     "(",   ")"};
   std::vector<TCompletionHint> filtered;
   for (const auto& original_hint : hints) {
     if (original_hint.type != TCompletionHintType::KEYWORD) {

--- a/ThriftHandler/TokenCompletionHints.h
+++ b/ThriftHandler/TokenCompletionHints.h
@@ -41,12 +41,4 @@ void get_column_hints(std::vector<TCompletionHint>& hints,
                       const std::string& last_word,
                       const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table);
 
-// Returns table hints for all keys which start with `last_word` from `column_names_by_table`.
-void get_table_hints(std::vector<TCompletionHint>& hints,
-                     const std::string& last_word,
-                     const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table);
-
-// Returns keyword hints which start with "keyword_prefix".
-std::vector<TCompletionHint> get_keyword_hints(const std::string& keyword_prefix);
-
 #endif  // THRIFTHANDLER_TOKENCOMPLETIONHINTS_H

--- a/java/calcite/src/main/java/com/mapd/calcite/parser/MapDParser.java
+++ b/java/calcite/src/main/java/com/mapd/calcite/parser/MapDParser.java
@@ -16,6 +16,7 @@
 package com.mapd.calcite.parser;
 
 import com.mapd.parser.server.ExtensionFunction;
+import java.util.List;
 import java.util.Map;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.plan.RelOptUtil;
@@ -113,8 +114,8 @@ public final class MapDParser {
     return res;
   }
 
-  public MapDPlanner.CompletionResult getCompletionHints(String sql, int cursor) {
-    return ((MapDPlanner) getPlanner()).getCompletionHints(sql, cursor);
+  public MapDPlanner.CompletionResult getCompletionHints(String sql, int cursor, List<String> visible_tables) {
+    return ((MapDPlanner) getPlanner()).getCompletionHints(sql, cursor, visible_tables);
   }
 
   RelRoot queryToSqlNode(final String sql, final boolean legacy_syntax) throws SqlParseException, ValidationException, RelConversionException {

--- a/java/calcite/src/main/java/com/mapd/parser/server/CalciteServerHandler.java
+++ b/java/calcite/src/main/java/com/mapd/parser/server/CalciteServerHandler.java
@@ -173,8 +173,8 @@ class CalciteServerHandler implements CalciteServer.Iface {
   }
 
   @Override
-  public List<TCompletionHint> getCompletionHints(String user, String session,
-      String catalog, String sql, int cursor) throws TException {
+  public List<TCompletionHint> getCompletionHints(String user, String session, String catalog,
+      List<String> visible_tables, String sql, int cursor) throws TException {
     callCount++;
     MapDParser parser;
     try {
@@ -190,7 +190,7 @@ class CalciteServerHandler implements CalciteServer.Iface {
 
     MapDPlanner.CompletionResult completion_result;
     try {
-      completion_result = parser.getCompletionHints(sql, cursor);
+      completion_result = parser.getCompletionHints(sql, cursor, visible_tables);
     } catch (Exception ex) {
       String msg = "Could not retrieve completion hints: " + ex.getMessage();
       MAPDLOGGER.error(msg);

--- a/java/calcite/src/main/java/org/apache/calcite/prepare/MapDPlanner.java
+++ b/java/calcite/src/main/java/org/apache/calcite/prepare/MapDPlanner.java
@@ -39,7 +39,6 @@ import org.apache.calcite.rex.RexExecutor;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
-import org.apache.calcite.sql.advise.SqlAdvisorValidator;
 import org.apache.calcite.sql.advise.SqlAdvisor;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -182,15 +181,18 @@ public class MapDPlanner implements Planner {
     }
   }
 
-  public CompletionResult getCompletionHints(final String sql, final int cursor) {
+  public CompletionResult getCompletionHints(
+      final String sql,
+      final int cursor,
+      final List<String> visibleTables) {
     switch (state) {
     case STATE_0_CLOSED:
     case STATE_1_RESET:
       ready();
     }
-    SqlAdvisorValidator advisor_validator = new SqlAdvisorValidator(
+    MapDSqlAdvisorValidator advisor_validator = new MapDSqlAdvisorValidator(visibleTables,
       config.getOperatorTable(), createCatalogReader(), getTypeFactory(), SqlConformanceEnum.LENIENT);
-    SqlAdvisor advisor = new SqlAdvisor(advisor_validator);
+    SqlAdvisor advisor = new MapDSqlAdvisor(advisor_validator);
     String[] replaced = new String[1];
     int adjusted_cursor = cursor < 0 ? sql.length() : cursor;
     java.util.List<SqlMoniker> hints = advisor.getCompletionHints(sql, adjusted_cursor, replaced);

--- a/java/calcite/src/main/java/org/apache/calcite/prepare/MapDSqlAdvisor.java
+++ b/java/calcite/src/main/java/org/apache/calcite/prepare/MapDSqlAdvisor.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.prepare;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.sql.advise.SqlAdvisor;
+import org.apache.calcite.sql.validate.SqlMoniker;
+import org.apache.calcite.sql.validate.SqlMonikerImpl;
+import org.apache.calcite.sql.validate.SqlMonikerType;
+
+class MapDSqlAdvisor extends SqlAdvisor {
+  public MapDSqlAdvisor(MapDSqlAdvisorValidator validator) {
+    super(validator);
+    this.permissionsAwareValidator = validator;
+  }
+
+  @Override
+  public List<SqlMoniker> getCompletionHints(String sql, int cursor, String[] replaced) {
+    // search backward starting from current position to find a "word"
+    int wordStart = cursor;
+    boolean quoted = false;
+    while (wordStart > 0 && Character.isJavaIdentifierPart(sql.charAt(wordStart - 1))) {
+      --wordStart;
+    }
+    if ((wordStart > 0) && (sql.charAt(wordStart - 1) == '"')) {
+      quoted = true;
+      --wordStart;
+    }
+
+    if (wordStart < 0) {
+      return java.util.Collections.emptyList();
+    }
+
+    // Search forwards to the end of the word we should remove. Eat up
+    // trailing double-quote, if any
+    int wordEnd = cursor;
+    while (wordEnd < sql.length() && Character.isJavaIdentifierPart(sql.charAt(wordEnd))) {
+      ++wordEnd;
+    }
+    if (quoted && (wordEnd < sql.length()) && (sql.charAt(wordEnd) == '"')) {
+      ++wordEnd;
+    }
+
+    // remove the partially composed identifier from the
+    // sql statement - otherwise we get a parser exception
+    String word = replaced[0] = sql.substring(wordStart, cursor);
+    if (wordStart < wordEnd) {
+      sql = sql.substring(0, wordStart) + sql.substring(wordEnd, sql.length());
+    }
+
+    // The table hints come from validator with a database prefix,
+    // which is inconsistent with how tables are used in the query.
+    List<SqlMoniker> completionHints = stripDatabaseFromTableHints(getCompletionHints0(sql, wordStart));
+
+    if (permissionsAwareValidator.hasViolatedTablePermissions()) {
+      return new ArrayList<>();
+    }
+
+    completionHints = applyPermissionsToTableHints(completionHints);
+
+    // If cursor was part of the way through a word, only include hints
+    // which start with that word in the result.
+    final List<SqlMoniker> result;
+    if (word.length() > 0) {
+      result = new java.util.ArrayList<SqlMoniker>();
+      if (quoted) {
+        // Quoted identifier. Case-sensitive match.
+        word = word.substring(1);
+        for (SqlMoniker hint : completionHints) {
+          String cname = hint.toString();
+          if (cname.startsWith(word)) {
+            result.add(hint);
+          }
+        }
+      } else {
+        // Regular identifier. Case-insensitive match.
+        for (SqlMoniker hint : completionHints) {
+          String cname = hint.toString();
+          if ((cname.length() >= word.length()) && cname.substring(0, word.length()).equalsIgnoreCase(word)) {
+            result.add(hint);
+          }
+        }
+      }
+    } else {
+      result = completionHints;
+    }
+
+    return result;
+  }
+
+  private static List<SqlMoniker> stripDatabaseFromTableHints(final List<SqlMoniker> completionHints) {
+    List<SqlMoniker> strippedCompletionHints = new ArrayList<>();
+    for (final SqlMoniker hint : completionHints) {
+      if (hint.getType() == SqlMonikerType.TABLE && hint.getFullyQualifiedNames().size() == 2) {
+        final String tableName = hint.getFullyQualifiedNames().get(1);
+        strippedCompletionHints.add(new SqlMonikerImpl(tableName, SqlMonikerType.TABLE));
+      } else {
+        strippedCompletionHints.add(hint);
+      }
+    }
+    return strippedCompletionHints;
+  }
+
+  private List<SqlMoniker> applyPermissionsToTableHints(final List<SqlMoniker> completionHints) {
+    List<SqlMoniker> completionHintsWithPermissions = new ArrayList<>();
+    for (final SqlMoniker hint : completionHints) {
+      if (hint.getType() == SqlMonikerType.TABLE) {
+        // Database was stripped in previous step.
+        assert hint.getFullyQualifiedNames().size() == 1;
+        // Don't return tables which aren't visible per the permissions.
+        if (permissionsAwareValidator.tableViolatesPermissions(hint.toString())) {
+          continue;
+        } else {
+          completionHintsWithPermissions.add(hint);
+        }
+      } else {
+        completionHintsWithPermissions.add(hint);
+      }
+    }
+    return completionHintsWithPermissions;
+  }
+
+  private MapDSqlAdvisorValidator permissionsAwareValidator;
+}

--- a/java/calcite/src/main/java/org/apache/calcite/prepare/MapDSqlAdvisorValidator.java
+++ b/java/calcite/src/main/java/org/apache/calcite/prepare/MapDSqlAdvisorValidator.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.prepare;
+
+import java.util.List;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.runtime.CalciteException;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.advise.SqlAdvisorValidator;
+import org.apache.calcite.sql.validate.SqlConformance;
+import org.apache.calcite.sql.validate.SqlValidatorCatalogReader;
+import org.apache.calcite.sql.validate.SqlValidatorScope;
+import org.apache.calcite.util.Util;
+
+class MapDSqlAdvisorValidator extends SqlAdvisorValidator {
+  MapDSqlAdvisorValidator(List<String> visibleTables, SqlOperatorTable opTab, SqlValidatorCatalogReader catalogReader,
+      RelDataTypeFactory typeFactory, SqlConformance conformance) {
+    super(opTab, catalogReader, typeFactory, conformance);
+    this.visibleTables = visibleTables;
+  }
+
+  @Override
+  protected void validateGroupClause(SqlSelect select) {
+    try {
+      SqlNodeList groupList = select.getGroup();
+      if (groupList == null) {
+        return;
+      }
+      // Validate the group items so that completions are available for them.
+      // For some reason, the base class doesn't do it.
+      for (final SqlNode groupItem : groupList) {
+        final SqlValidatorScope groupScope = getGroupScope(select);
+        groupItem.validate(this, groupScope);
+      }
+      super.validateGroupClause(select);
+    } catch (CalciteException e) {
+      Util.swallow(e, TRACER);
+    }
+  }
+
+  @Override
+  protected void validateFrom(SqlNode node, RelDataType targetRowType, SqlValidatorScope scope) {
+    try {
+      // Must not return columns from a table which is not visible. Since column
+      // hints are returned without their table, we must keep track of visibility
+      // violations during validation.
+      if (node.getKind() == SqlKind.IDENTIFIER && tableViolatesPermissions(node.toString())) {
+        violatedTablePermissions = true;
+      }
+      super.validateFrom(node, targetRowType, scope);
+    } catch (CalciteException e) {
+      Util.swallow(e, TRACER);
+    }
+  }
+
+  // Check if the given table name is invisible (per the permissions). The dummy
+  // table inserted by the partial parser is allowed (starts with underscore).
+  boolean tableViolatesPermissions(final String tableName) {
+    return !tableName.isEmpty() && Character.isAlphabetic(tableName.charAt(0))
+        && visibleTables.stream().noneMatch(visibleTableName -> visibleTableName.equalsIgnoreCase(tableName));
+  }
+
+  boolean hasViolatedTablePermissions() {
+    return violatedTablePermissions;
+  }
+
+  private List<String> visibleTables;
+  private boolean violatedTablePermissions = false;
+}

--- a/java/thrift/calciteserver.thrift
+++ b/java/thrift/calciteserver.thrift
@@ -19,6 +19,7 @@ service CalciteServer {
    TPlanResult process(1:string user 2:string passwd 3:string catalog 4:string sql_text 5:bool legacySyntax 6:bool isexplain) throws (1:InvalidParseRequest parseErr),
    string getExtensionFunctionWhitelist()
    void updateMetadata(1: string catalog, 2:string table),
-   list<completion_hints.TCompletionHint> getCompletionHints(1:string user 2:string passwd 3:string catalog, 4:string sql, 5:i32 cursor)
+   list<completion_hints.TCompletionHint> getCompletionHints(1:string user, 2:string passwd, 3:string catalog,
+    4:list<string> visible_tables, 5:string sql, 6:i32 cursor)
 
 }


### PR DESCRIPTION
Bring back the Calcite-based completion with improvements. It now
follows the permissions, can auto-complete grouped columns and doesn't
conflate column and table suggestions anymore.