### PR TITLE
Choose smartly between FROM keyword hint and column hints

### DIFF
--- a/Tests/TokenCompletionHintsTest.cpp
+++ b/Tests/TokenCompletionHintsTest.cpp
@@ -150,6 +150,14 @@ TEST(Completion, FilterKeywords) {
   ASSERT_EQ(expected_filtered_hints, filtered_hints);
 }
 
+TEST(Completion, ShouldSuggestColumnHints) {
+  ASSERT_FALSE(should_suggest_column_hints("SELECT x"));
+  ASSERT_FALSE(should_suggest_column_hints("SELECT x "));
+  ASSERT_TRUE(should_suggest_column_hints("SELECT x,"));
+  ASSERT_TRUE(should_suggest_column_hints("SELECT x , "));
+  ASSERT_TRUE(should_suggest_column_hints("SELECT "));
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/ThriftHandler/MapDHandler.cpp
+++ b/ThriftHandler/MapDHandler.cpp
@@ -814,7 +814,10 @@ void MapDHandler::get_token_based_completions(std::vector<TCompletionHint>& hint
       return;
     }
     // Not much information to use, just retrieve column names which match the prefix.
-    get_column_hints(hints, last_word, column_names_by_table);
+    if (should_suggest_column_hints(sql)) {
+      get_column_hints(hints, last_word, column_names_by_table);
+      return;
+    }
     const std::string kFromKeyword{"FROM"};
     if (boost::istarts_with(kFromKeyword, last_word)) {
       TCompletionHint keyword_hint;

--- a/ThriftHandler/TokenCompletionHints.cpp
+++ b/ThriftHandler/TokenCompletionHints.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/tokenizer.hpp>
 
 namespace {
 
@@ -133,4 +134,18 @@ void get_column_hints(std::vector<TCompletionHint>& hints,
   if (!column_hint.hints.empty()) {
     hints.push_back(column_hint);
   }
+}
+
+bool should_suggest_column_hints(const std::string& partial_query) {
+  boost::char_separator<char> sep(" \t\n", ",");
+  boost::tokenizer<boost::char_separator<char>> tokens(partial_query, sep);
+  const auto token_count = std::distance(tokens.begin(), tokens.end());
+  if (token_count == 1) {
+    return true;
+  }
+  std::string last_token;
+  for (const auto& token : tokens) {
+    last_token = token;
+  }
+  return last_token == ",";
 }

--- a/ThriftHandler/TokenCompletionHints.h
+++ b/ThriftHandler/TokenCompletionHints.h
@@ -41,4 +41,8 @@ void get_column_hints(std::vector<TCompletionHint>& hints,
                       const std::string& last_word,
                       const std::unordered_map<std::string, std::unordered_set<std::string>>& column_names_by_table);
 
+// Returns true iff it should suggest columns or just the FROM keyword,
+// should be called for partial queries after SELECT but before FROM.
+bool should_suggest_column_hints(const std::string& partial_query);
+
 #endif  // THRIFTHANDLER_TOKENCOMPLETIONHINTS_H


### PR DESCRIPTION
After SELECT but before FROM, only suggest column if it's the first
token after SELECT or there's a trailing comma.