### PR TITLE
Disable sharding for baseline outer joins as well

### DIFF
--- a/QueryEngine/JoinHashTable.cpp
+++ b/QueryEngine/JoinHashTable.cpp
@@ -173,7 +173,7 @@ bool shard_count_less_or_equal_device_count(const int outer_table_id, const Exec
 size_t get_shard_count(std::pair<const Analyzer::ColumnVar*, const Analyzer::Expr*> equi_pair,
                        const RelAlgExecutionUnit& ra_exe_unit,
                        const Executor* executor) {
-  if (executor->isOuterJoin()) {
+  if (executor->isOuterJoin() || executor->containsLeftDeepOuterJoin()) {
     return 0;
   }
   const auto lhs_col = equi_pair.first;

--- a/Tests/ExecuteTest.cpp
+++ b/Tests/ExecuteTest.cpp
@@ -3521,6 +3521,7 @@ TEST(Select, Joins_LeftOuterJoin) {
       "JOIN hash_join_test ON test.str = hash_join_test.str GROUP BY test_inner.y, hash_join_test.x ORDER BY "
       "test_inner.y ASC, hash_join_test.x ASC;",
       dt);
+    c("SELECT COUNT(*) FROM test LEFT JOIN test_inner ON test.str = test_inner.str AND test.x = test_inner.x;", dt);
   }
 }
 


### PR DESCRIPTION
The fragment distribution logic must change a bit before outer joins can
be sharded. Disable for now for correctness' sake, which wasn't done for
the baseline join hash table layout (used for joins on multiple columns).