### PR TITLE
Optimize single table projection queries memory usage

### DIFF
--- a/Fragmenter/Fragmenter.h
+++ b/Fragmenter/Fragmenter.h
@@ -140,6 +140,8 @@ class TableInfo {
 
   void setPhysicalNumTuples(const size_t physNumTuples) { numTuples = physNumTuples; }
 
+  size_t getFragmentNumTuplesUpperBound() const;
+
   std::vector<int> chunkKeyPrefix;
   std::deque<FragmentInfo> fragments;
 

--- a/QueryEngine/Execute.cpp
+++ b/QueryEngine/Execute.cpp
@@ -1380,7 +1380,8 @@ void Executor::dispatchFragments(
                                           frag_list_idx % context_count,
                                           rowid_lookup_key));
       ++frag_list_idx;
-      if (is_sample_query(ra_exe_unit) && fragment.getNumTuples() >= ra_exe_unit.scan_limit) {
+      const auto sample_query_limit = ra_exe_unit.sort_info.limit + ra_exe_unit.sort_info.offset;
+      if (is_sample_query(ra_exe_unit) && sample_query_limit > 0 && fragment.getNumTuples() >= sample_query_limit) {
         break;
       }
     }

--- a/QueryEngine/GroupByRuntime.cpp
+++ b/QueryEngine/GroupByRuntime.cpp
@@ -215,10 +215,11 @@ extern "C" ALWAYS_INLINE DEVICE int64_t* get_group_value_one_key_with_watchdog(
 extern "C" ALWAYS_INLINE DEVICE int64_t* get_scan_output_slot(int64_t* output_buffer,
                                                               const uint32_t output_buffer_entry_count,
                                                               const uint32_t pos,
+                                                              const int64_t offset_in_fragment,
                                                               const uint32_t row_size_quad) {
   uint64_t off = static_cast<uint64_t>(pos) * static_cast<uint64_t>(row_size_quad);
   if (pos < output_buffer_entry_count) {
-    output_buffer[off] = pos;
+    output_buffer[off] = offset_in_fragment;
     return output_buffer + off + 1;
   }
   return NULL;

--- a/QueryEngine/InputMetadata.cpp
+++ b/QueryEngine/InputMetadata.cpp
@@ -309,3 +309,14 @@ size_t Fragmenter_Namespace::TableInfo::getNumTuplesUpperBound() const {
   }
   return numTuples;
 }
+
+size_t Fragmenter_Namespace::TableInfo::getFragmentNumTuplesUpperBound() const {
+  if (!fragments.empty() && fragments.front().resultSet) {
+    return fragments.front().resultSet->entryCount();
+  }
+  size_t fragment_num_tupples_upper_bound = 0;
+  for (const auto& fragment : fragments) {
+    fragment_num_tupples_upper_bound = std::max(fragment.getNumTuples(), fragment_num_tupples_upper_bound);
+  }
+  return fragment_num_tupples_upper_bound;
+}

--- a/QueryEngine/RelAlgExecutor.cpp
+++ b/QueryEngine/RelAlgExecutor.cpp
@@ -1626,7 +1626,12 @@ ssize_t RelAlgExecutor::getFilteredCountAll(const WorkUnit& work_unit,
   CHECK(count_scalar_tv);
   const auto count_ptr = boost::get<int64_t>(count_scalar_tv);
   CHECK(count_ptr);
-  return std::max(*count_ptr, int64_t(1));
+  CHECK_GE(*count_ptr, 0);
+  auto count_upper_bound = static_cast<size_t>(*count_ptr);
+  if (table_infos.size() == 1) {
+    count_upper_bound = std::min(table_infos.front().info.getFragmentNumTuplesUpperBound(), count_upper_bound);
+  }
+  return std::max(count_upper_bound, size_t(1));
 }
 
 bool RelAlgExecutor::isRowidLookup(const WorkUnit& work_unit) {


### PR DESCRIPTION
Don't store lazily fetched columns multiple times. Also cap the projection buffer size by the size of the fragment.